### PR TITLE
Multi-user collaborative kanban with ops log and trust

### DIFF
--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,7 +1,8 @@
 import { Agent } from '@atproto/api';
 import { BrowserOAuthClient, buildAtprotoLoopbackClientMetadata } from '@atproto/oauth-client-browser';
 
-const OAUTH_SCOPE = 'atproto repo:blue.kanban.board repo:blue.kanban.task';
+const OAUTH_SCOPE =
+	'atproto repo:blue.kanban.board repo:blue.kanban.task repo:blue.kanban.op repo:blue.kanban.trust';
 
 let agent = $state<Agent | null>(null);
 let did = $state<string | null>(null);

--- a/src/lib/components/AuthorBadge.svelte
+++ b/src/lib/components/AuthorBadge.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	let {
+		did,
+		isCurrentUser = false
+	}: {
+		did: string;
+		isCurrentUser?: boolean;
+	} = $props();
+
+	const shortDid = $derived(
+		did.length > 24 ? did.slice(0, 14) + '...' + did.slice(-6) : did
+	);
+</script>
+
+<span class="author-badge" class:own={isCurrentUser} title={did}>
+	{shortDid}
+</span>
+
+<style>
+	.author-badge {
+		display: inline-block;
+		font-size: 0.625rem;
+		color: var(--color-text-secondary);
+		background: var(--color-bg);
+		padding: 0.0625rem 0.375rem;
+		border-radius: var(--radius-sm);
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-family: monospace;
+	}
+
+	.author-badge.own {
+		color: var(--color-primary);
+		background: var(--color-primary-alpha, rgba(0, 102, 204, 0.08));
+	}
+</style>

--- a/src/lib/components/ProposalPanel.svelte
+++ b/src/lib/components/ProposalPanel.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import type { Op, Task } from '$lib/types.js';
+	import { grantTrust } from '$lib/trust.js';
+	import { getAuth } from '$lib/auth.svelte.js';
+
+	let {
+		proposals,
+		untrustedTasks,
+		boardUri,
+		onclose
+	}: {
+		proposals: Op[];
+		untrustedTasks: Task[];
+		boardUri: string;
+		onclose: () => void;
+	} = $props();
+
+	const auth = getAuth();
+
+	// Group everything by author DID
+	const groupedByAuthor = $derived.by(() => {
+		const map = new Map<string, { ops: Op[]; tasks: Task[] }>();
+
+		for (const task of untrustedTasks) {
+			const entry = map.get(task.did) || { ops: [], tasks: [] };
+			entry.tasks.push(task);
+			map.set(task.did, entry);
+		}
+
+		for (const op of proposals) {
+			const entry = map.get(op.did) || { ops: [], tasks: [] };
+			entry.ops.push(op);
+			map.set(op.did, entry);
+		}
+
+		return map;
+	});
+
+	async function trustUser(trustedDid: string) {
+		if (!auth.did) return;
+		await grantTrust(auth.did, trustedDid, boardUri);
+	}
+
+	function describeOp(op: Op): string {
+		const parts: string[] = [];
+		if (op.fields.title !== undefined) parts.push(`title to "${op.fields.title}"`);
+		if (op.fields.description !== undefined) parts.push('description');
+		if (op.fields.columnId !== undefined) parts.push('column');
+		if (op.fields.order !== undefined) parts.push('order');
+		return parts.length > 0 ? `Change ${parts.join(', ')}` : 'Unknown change';
+	}
+
+	function shortDid(did: string): string {
+		return did.length > 24 ? did.slice(0, 14) + '...' + did.slice(-6) : did;
+	}
+</script>
+
+<div class="panel-backdrop" onclick={onclose} role="presentation">
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="panel" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
+		<div class="panel-header">
+			<h3>Pending Proposals</h3>
+			<button class="close-btn" onclick={onclose}>Close</button>
+		</div>
+
+		{#if groupedByAuthor.size === 0}
+			<p class="empty">No pending proposals.</p>
+		{:else}
+			{#each [...groupedByAuthor.entries()] as [authorDid, { ops, tasks }]}
+				<div class="author-section">
+					<div class="author-header">
+						<span class="author-did" title={authorDid}>{shortDid(authorDid)}</span>
+						<button class="trust-btn" onclick={() => trustUser(authorDid)}>
+							Trust Editor
+						</button>
+					</div>
+					{#if tasks.length > 0}
+						<div class="subsection-label">Tasks ({tasks.length})</div>
+						<ul class="item-list">
+							{#each tasks as task}
+								<li class="item">{task.title}</li>
+							{/each}
+						</ul>
+					{/if}
+					{#if ops.length > 0}
+						<div class="subsection-label">Edits ({ops.length})</div>
+						<ul class="item-list">
+							{#each ops as op}
+								<li class="item">{describeOp(op)}</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.panel-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.3);
+		z-index: 100;
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.panel {
+		width: 360px;
+		max-width: 90vw;
+		height: 100%;
+		background: var(--color-surface);
+		box-shadow: var(--shadow-lg);
+		overflow-y: auto;
+		padding: 1rem;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1rem;
+		padding-bottom: 0.75rem;
+		border-bottom: 1px solid var(--color-border-light);
+	}
+
+	.panel-header h3 {
+		margin: 0;
+		font-size: 0.9375rem;
+		font-weight: 600;
+	}
+
+	.close-btn {
+		padding: 0.25rem 0.5rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-sm);
+		background: var(--color-surface);
+		color: var(--color-text-secondary);
+		font-size: 0.75rem;
+		cursor: pointer;
+	}
+
+	.empty {
+		color: var(--color-text-secondary);
+		font-size: 0.8125rem;
+		text-align: center;
+		padding: 2rem 0;
+	}
+
+	.author-section {
+		margin-bottom: 1rem;
+		padding: 0.75rem;
+		background: var(--color-bg);
+		border-radius: var(--radius-md);
+	}
+
+	.author-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.author-did {
+		font-family: monospace;
+		font-size: 0.6875rem;
+		color: var(--color-text-secondary);
+	}
+
+	.subsection-label {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		color: var(--color-text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		margin-top: 0.375rem;
+		margin-bottom: 0.25rem;
+	}
+
+	.trust-btn {
+		padding: 0.25rem 0.625rem;
+		background: var(--color-primary);
+		color: white;
+		border: none;
+		border-radius: var(--radius-sm);
+		font-size: 0.6875rem;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
+	.trust-btn:hover {
+		background: var(--color-primary-hover);
+	}
+
+	.item-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.item {
+		font-size: 0.75rem;
+		color: var(--color-text-secondary);
+		padding: 0.25rem 0;
+		border-bottom: 1px solid var(--color-border-light);
+	}
+
+	.item:last-child {
+		border-bottom: none;
+	}
+</style>

--- a/src/lib/components/SyncStatus.svelte
+++ b/src/lib/components/SyncStatus.svelte
@@ -5,13 +5,17 @@
 	const pendingCount = useLiveQuery<number>(async () => {
 		const boards = await db.boards.where('syncStatus').equals('pending').count();
 		const tasks = await db.tasks.where('syncStatus').equals('pending').count();
-		return boards + tasks;
+		const ops = await db.ops.where('syncStatus').equals('pending').count();
+		const trusts = await db.trusts.where('syncStatus').equals('pending').count();
+		return boards + tasks + ops + trusts;
 	});
 
 	const errorCount = useLiveQuery<number>(async () => {
 		const boards = await db.boards.where('syncStatus').equals('error').count();
 		const tasks = await db.tasks.where('syncStatus').equals('error').count();
-		return boards + tasks;
+		const ops = await db.ops.where('syncStatus').equals('error').count();
+		const trusts = await db.trusts.where('syncStatus').equals('error').count();
+		return boards + tasks + ops + trusts;
 	});
 </script>
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,14 +1,25 @@
 import Dexie, { type EntityTable } from 'dexie';
-import type { Board, Task } from './types.js';
+import type { Board, Task, Op, Trust, KnownParticipant } from './types.js';
 
 const db = new Dexie('at-kanban') as Dexie & {
 	boards: EntityTable<Board, 'id'>;
 	tasks: EntityTable<Task, 'id'>;
+	ops: EntityTable<Op, 'id'>;
+	trusts: EntityTable<Trust, 'id'>;
+	knownParticipants: EntityTable<KnownParticipant, 'id'>;
 };
 
 db.version(1).stores({
 	boards: '++id, rkey, did, syncStatus',
 	tasks: '++id, rkey, did, columnId, boardUri, order, syncStatus'
+});
+
+db.version(2).stores({
+	boards: '++id, rkey, did, syncStatus',
+	tasks: '++id, rkey, did, columnId, boardUri, order, syncStatus, [did+rkey]',
+	ops: '++id, rkey, did, targetTaskUri, boardUri, createdAt, syncStatus, [did+rkey]',
+	trusts: '++id, rkey, did, trustedDid, boardUri, syncStatus, [did+boardUri+trustedDid]',
+	knownParticipants: '++id, did, boardUri, [did+boardUri]'
 });
 
 export { db };

--- a/src/lib/jetstream.ts
+++ b/src/lib/jetstream.ts
@@ -1,0 +1,228 @@
+import { db } from './db.js';
+import { TASK_COLLECTION, OP_COLLECTION } from './tid.js';
+
+const JETSTREAM_URL = 'wss://jetstream2.us-east.bsky.network/subscribe';
+
+export interface JetstreamCommitEvent {
+	did: string;
+	time_us: number;
+	kind: 'commit';
+	commit: {
+		rev: string;
+		operation: 'create' | 'update' | 'delete';
+		collection: string;
+		rkey: string;
+		record?: Record<string, unknown>;
+	};
+}
+
+export interface JetstreamOptions {
+	wantedCollections: string[];
+	cursor?: number;
+	onEvent: (event: JetstreamCommitEvent) => void;
+	onError?: (error: Event) => void;
+	onConnect?: () => void;
+}
+
+const CURSOR_KEY = 'jetstream-cursor';
+const CURSOR_SAVE_INTERVAL = 5000;
+
+export class JetstreamClient {
+	private ws: WebSocket | null = null;
+	private options: JetstreamOptions;
+	private reconnectDelay = 1000;
+	private maxReconnectDelay = 30000;
+	private shouldReconnect = true;
+	private lastCursor: number | null = null;
+	private cursorSaveTimer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(options: JetstreamOptions) {
+		this.options = options;
+		if (options.cursor) {
+			this.lastCursor = options.cursor;
+		}
+	}
+
+	connect(): void {
+		const params = new URLSearchParams();
+		for (const collection of this.options.wantedCollections) {
+			params.append('wantedCollections', collection);
+		}
+		if (this.lastCursor) {
+			params.append('cursor', String(this.lastCursor));
+		}
+
+		const url = `${JETSTREAM_URL}?${params.toString()}`;
+		this.ws = new WebSocket(url);
+
+		this.ws.onopen = () => {
+			this.reconnectDelay = 1000;
+			this.options.onConnect?.();
+			this.startCursorSaving();
+		};
+
+		this.ws.onmessage = (event: MessageEvent) => {
+			this.handleMessage(event);
+		};
+
+		this.ws.onerror = (event: Event) => {
+			this.options.onError?.(event);
+		};
+
+		this.ws.onclose = () => {
+			this.stopCursorSaving();
+			this.handleClose();
+		};
+	}
+
+	private handleMessage(event: MessageEvent): void {
+		try {
+			const data = JSON.parse(event.data as string) as JetstreamCommitEvent;
+			if (data.kind === 'commit' && data.time_us) {
+				this.lastCursor = data.time_us;
+				this.options.onEvent(data);
+			}
+		} catch {
+			// Ignore malformed messages
+		}
+	}
+
+	private handleClose(): void {
+		if (!this.shouldReconnect) return;
+
+		setTimeout(() => {
+			if (this.shouldReconnect) {
+				this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
+				this.connect();
+			}
+		}, this.reconnectDelay);
+	}
+
+	private startCursorSaving(): void {
+		this.cursorSaveTimer = setInterval(() => {
+			if (this.lastCursor) {
+				saveJetstreamCursor(this.lastCursor).catch(console.error);
+			}
+		}, CURSOR_SAVE_INTERVAL);
+	}
+
+	private stopCursorSaving(): void {
+		if (this.cursorSaveTimer) {
+			clearInterval(this.cursorSaveTimer);
+			this.cursorSaveTimer = null;
+		}
+		// Save final cursor
+		if (this.lastCursor) {
+			saveJetstreamCursor(this.lastCursor).catch(console.error);
+		}
+	}
+
+	disconnect(): void {
+		this.shouldReconnect = false;
+		this.stopCursorSaving();
+		this.ws?.close();
+		this.ws = null;
+	}
+}
+
+export async function loadJetstreamCursor(): Promise<number | undefined> {
+	try {
+		const value = localStorage.getItem(CURSOR_KEY);
+		return value ? Number(value) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function saveJetstreamCursor(cursor: number): Promise<void> {
+	try {
+		localStorage.setItem(CURSOR_KEY, String(cursor));
+	} catch {
+		// Ignore storage errors
+	}
+}
+
+/**
+ * Process a Jetstream event and upsert it into the local DB if it's relevant
+ * to any board we're tracking. Returns the DID of the event author if it was
+ * relevant (for known participant tracking).
+ */
+export async function processJetstreamEvent(
+	event: JetstreamCommitEvent,
+	watchedBoardUris: Set<string>
+): Promise<string | null> {
+	const { did, commit } = event;
+
+	if (commit.operation === 'delete') {
+		// Handle deletions
+		if (commit.collection === TASK_COLLECTION) {
+			const existing = await db.tasks.where('[did+rkey]').equals([did, commit.rkey]).first();
+			if (existing?.id) {
+				await db.tasks.delete(existing.id);
+				return did;
+			}
+		} else if (commit.collection === OP_COLLECTION) {
+			const existing = await db.ops.where('[did+rkey]').equals([did, commit.rkey]).first();
+			if (existing?.id) {
+				await db.ops.delete(existing.id);
+				return did;
+			}
+		}
+		return null;
+	}
+
+	if (!commit.record) return null;
+
+	const record = commit.record;
+	const boardUri = record.boardUri as string | undefined;
+
+	// Only process records that reference boards we're watching
+	if (!boardUri || !watchedBoardUris.has(boardUri)) return null;
+
+	if (commit.collection === TASK_COLLECTION) {
+		const existing = await db.tasks.where('[did+rkey]').equals([did, commit.rkey]).first();
+
+		const taskData = {
+			rkey: commit.rkey,
+			did,
+			title: (record.title as string) ?? '',
+			description: record.description as string | undefined,
+			columnId: (record.columnId as string) ?? '',
+			boardUri,
+			order: (record.order as number) ?? 0,
+			createdAt: (record.createdAt as string) ?? new Date().toISOString(),
+			updatedAt: record.updatedAt as string | undefined,
+			syncStatus: 'synced' as const
+		};
+
+		if (existing?.id) {
+			await db.tasks.update(existing.id, taskData);
+		} else {
+			await db.tasks.add(taskData);
+		}
+		return did;
+	}
+
+	if (commit.collection === OP_COLLECTION) {
+		const existing = await db.ops.where('[did+rkey]').equals([did, commit.rkey]).first();
+
+		const opData = {
+			rkey: commit.rkey,
+			did,
+			targetTaskUri: (record.targetTaskUri as string) ?? '',
+			boardUri,
+			fields: (record.fields as Record<string, unknown>) ?? {},
+			createdAt: (record.createdAt as string) ?? new Date().toISOString(),
+			syncStatus: 'synced' as const
+		};
+
+		if (existing?.id) {
+			await db.ops.update(existing.id, opData);
+		} else {
+			await db.ops.add(opData);
+		}
+		return did;
+	}
+
+	return null;
+}

--- a/src/lib/lexicons/op.json
+++ b/src/lib/lexicons/op.json
@@ -1,0 +1,58 @@
+{
+  "lexicon": 1,
+  "id": "blue.kanban.op",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "An operation proposing a change to a kanban task",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["targetTaskUri", "boardUri", "fields", "createdAt"],
+        "properties": {
+          "targetTaskUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the task this op targets"
+          },
+          "boardUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the board this op pertains to"
+          },
+          "fields": {
+            "type": "ref",
+            "ref": "#opFields",
+            "description": "The fields to change on the target task"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of the operation, used for LWW resolution"
+          }
+        }
+      }
+    },
+    "opFields": {
+      "type": "object",
+      "description": "Subset of task fields to override. Only present fields are applied.",
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 1024
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 10240
+        },
+        "columnId": {
+          "type": "string"
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/src/lib/lexicons/trust.json
+++ b/src/lib/lexicons/trust.json
@@ -1,0 +1,32 @@
+{
+  "lexicon": 1,
+  "id": "blue.kanban.trust",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A trust grant for a user on a specific board",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["trustedDid", "boardUri", "createdAt"],
+        "properties": {
+          "trustedDid": {
+            "type": "string",
+            "format": "did",
+            "description": "The DID of the user being trusted"
+          },
+          "boardUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the board this trust applies to"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the trust was granted"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/lib/materialize.ts
+++ b/src/lib/materialize.ts
@@ -1,0 +1,109 @@
+import { buildAtUri, TASK_COLLECTION } from './tid.js';
+import type { Task, Op, OpFields, MaterializedTask } from './types.js';
+
+const MUTABLE_FIELDS: (keyof OpFields)[] = ['title', 'description', 'columnId', 'order'];
+
+interface FieldState {
+	value: unknown;
+	timestamp: string;
+	author: string;
+}
+
+export function materializeTasks(
+	tasks: Task[],
+	ops: Op[],
+	trustedDids: Set<string>,
+	currentUserDid: string
+): MaterializedTask[] {
+	// Group ops by targetTaskUri
+	const opsByTask = new Map<string, Op[]>();
+	for (const op of ops) {
+		const list = opsByTask.get(op.targetTaskUri) || [];
+		list.push(op);
+		opsByTask.set(op.targetTaskUri, list);
+	}
+
+	return tasks.map((task) => {
+		const taskUri = buildAtUri(task.did, TASK_COLLECTION, task.rkey);
+		const taskOps = opsByTask.get(taskUri) || [];
+
+		// Separate trusted vs untrusted ops
+		const appliedOps: Op[] = [];
+		const pendingOps: Op[] = [];
+
+		for (const op of taskOps) {
+			if (
+				op.did === task.did ||
+				op.did === currentUserDid ||
+				trustedDids.has(op.did)
+			) {
+				appliedOps.push(op);
+			} else {
+				pendingOps.push(op);
+			}
+		}
+
+		// Start with base task values
+		const fieldStates: Record<string, FieldState> = {};
+		for (const field of MUTABLE_FIELDS) {
+			fieldStates[field] = {
+				value: task[field as keyof Task],
+				timestamp: task.updatedAt || task.createdAt,
+				author: task.did
+			};
+		}
+
+		// Apply trusted ops using LWW per field (sort ascending, later overwrites)
+		const sortedOps = [...appliedOps].sort((a, b) =>
+			a.createdAt.localeCompare(b.createdAt)
+		);
+
+		for (const op of sortedOps) {
+			for (const field of MUTABLE_FIELDS) {
+				const opValue = op.fields[field];
+				if (opValue !== undefined) {
+					const current = fieldStates[field];
+					if (op.createdAt > current.timestamp) {
+						fieldStates[field] = {
+							value: opValue,
+							timestamp: op.createdAt,
+							author: op.did
+						};
+					}
+				}
+			}
+		}
+
+		// Find the last modifier
+		let lastModifiedBy = task.did;
+		let lastModifiedAt = task.updatedAt || task.createdAt;
+		for (const field of MUTABLE_FIELDS) {
+			if (fieldStates[field].timestamp > lastModifiedAt) {
+				lastModifiedAt = fieldStates[field].timestamp;
+				lastModifiedBy = fieldStates[field].author;
+			}
+		}
+
+		return {
+			rkey: task.rkey,
+			did: task.did,
+			title: task.title,
+			description: task.description,
+			columnId: task.columnId,
+			boardUri: task.boardUri,
+			order: task.order,
+			createdAt: task.createdAt,
+			updatedAt: task.updatedAt,
+			sourceTask: task,
+			appliedOps,
+			pendingOps,
+			effectiveTitle: fieldStates.title.value as string,
+			effectiveDescription: fieldStates.description.value as string | undefined,
+			effectiveColumnId: fieldStates.columnId.value as string,
+			effectiveOrder: fieldStates.order.value as number,
+			ownerDid: task.did,
+			lastModifiedBy,
+			lastModifiedAt
+		};
+	});
+}

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -1,0 +1,36 @@
+import { db } from './db.js';
+import { generateTID, buildAtUri, TASK_COLLECTION } from './tid.js';
+import type { Op, OpFields, OpRecord, Task } from './types.js';
+
+export function shouldCreateOp(currentUserDid: string, task: Task): boolean {
+	return task.did !== currentUserDid;
+}
+
+export async function createOp(
+	authorDid: string,
+	targetTask: Task,
+	boardUri: string,
+	fields: OpFields
+): Promise<void> {
+	const targetTaskUri = buildAtUri(targetTask.did, TASK_COLLECTION, targetTask.rkey);
+
+	await db.ops.add({
+		rkey: generateTID(),
+		did: authorDid,
+		targetTaskUri,
+		boardUri,
+		fields,
+		createdAt: new Date().toISOString(),
+		syncStatus: 'pending'
+	});
+}
+
+export function opToRecord(op: Op): OpRecord {
+	return {
+		$type: 'blue.kanban.op',
+		targetTaskUri: op.targetTaskUri,
+		boardUri: op.boardUri,
+		fields: op.fields,
+		createdAt: op.createdAt
+	};
+}

--- a/src/lib/remote-sync.ts
+++ b/src/lib/remote-sync.ts
@@ -1,0 +1,219 @@
+import { db } from './db.js';
+import { TASK_COLLECTION, OP_COLLECTION, BOARD_COLLECTION } from './tid.js';
+import type { Task, Op, Board } from './types.js';
+
+// Cache resolved PDS endpoints to avoid repeated lookups
+const pdsCache = new Map<string, string>();
+
+/**
+ * Resolve a DID to its PDS service endpoint.
+ * For did:plc, queries plc.directory. For did:web, fetches /.well-known/did.json.
+ */
+async function resolvePDS(did: string): Promise<string | null> {
+	const cached = pdsCache.get(did);
+	if (cached) return cached;
+
+	try {
+		let didDoc: Record<string, unknown>;
+
+		if (did.startsWith('did:plc:')) {
+			const res = await fetch(`https://plc.directory/${did}`);
+			if (!res.ok) return null;
+			didDoc = await res.json();
+		} else if (did.startsWith('did:web:')) {
+			const host = did.slice('did:web:'.length).replaceAll(':', '/');
+			const res = await fetch(`https://${host}/.well-known/did.json`);
+			if (!res.ok) return null;
+			didDoc = await res.json();
+		} else {
+			return null;
+		}
+
+		// Extract the PDS service endpoint from the DID document
+		const services = didDoc.service as Array<{ id: string; type: string; serviceEndpoint: string }> | undefined;
+		const pds = services?.find(
+			(s) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
+		);
+		if (!pds?.serviceEndpoint) return null;
+
+		pdsCache.set(did, pds.serviceEndpoint);
+		return pds.serviceEndpoint;
+	} catch {
+		return null;
+	}
+}
+
+async function fetchRecordsFromRepo(
+	repoDid: string,
+	collection: string
+): Promise<Array<{ uri: string; value: Record<string, unknown> }>> {
+	const pds = await resolvePDS(repoDid);
+	if (!pds) return [];
+
+	const records: Array<{ uri: string; value: Record<string, unknown> }> = [];
+	let cursor: string | undefined;
+
+	do {
+		const params = new URLSearchParams({
+			repo: repoDid,
+			collection,
+			limit: '100'
+		});
+		if (cursor) params.set('cursor', cursor);
+
+		const res = await fetch(
+			`${pds}/xrpc/com.atproto.repo.listRecords?${params.toString()}`
+		);
+		if (!res.ok) break;
+
+		const data = await res.json();
+		records.push(...(data.records ?? []));
+		cursor = data.cursor;
+	} while (cursor);
+
+	return records;
+}
+
+export async function fetchRemoteTasks(
+	participantDid: string,
+	boardUri: string
+): Promise<void> {
+	const records = await fetchRecordsFromRepo(participantDid, TASK_COLLECTION);
+
+	for (const record of records) {
+		const value = record.value;
+		if (value.boardUri !== boardUri) continue;
+
+		const rkey = record.uri.split('/').pop()!;
+		const existing = await db.tasks
+			.where('[did+rkey]')
+			.equals([participantDid, rkey])
+			.first();
+
+		const taskData: Omit<Task, 'id'> = {
+			rkey,
+			did: participantDid,
+			title: (value.title as string) ?? '',
+			description: value.description as string | undefined,
+			columnId: (value.columnId as string) ?? '',
+			boardUri,
+			order: (value.order as number) ?? 0,
+			createdAt: (value.createdAt as string) ?? new Date().toISOString(),
+			updatedAt: value.updatedAt as string | undefined,
+			syncStatus: 'synced'
+		};
+
+		if (existing?.id) {
+			await db.tasks.update(existing.id, taskData);
+		} else {
+			await db.tasks.add(taskData as Task);
+		}
+	}
+}
+
+export async function fetchRemoteOps(
+	participantDid: string,
+	boardUri: string
+): Promise<void> {
+	const records = await fetchRecordsFromRepo(participantDid, OP_COLLECTION);
+
+	for (const record of records) {
+		const value = record.value;
+		if (value.boardUri !== boardUri) continue;
+
+		const rkey = record.uri.split('/').pop()!;
+		const existing = await db.ops
+			.where('[did+rkey]')
+			.equals([participantDid, rkey])
+			.first();
+
+		const opData: Omit<Op, 'id'> = {
+			rkey,
+			did: participantDid,
+			targetTaskUri: (value.targetTaskUri as string) ?? '',
+			boardUri,
+			fields: (value.fields as Op['fields']) ?? {},
+			createdAt: (value.createdAt as string) ?? new Date().toISOString(),
+			syncStatus: 'synced'
+		};
+
+		if (existing?.id) {
+			await db.ops.update(existing.id, opData);
+		} else {
+			await db.ops.add(opData as Op);
+		}
+	}
+}
+
+export async function fetchRemoteBoard(
+	ownerDid: string,
+	collection: string,
+	rkey: string
+): Promise<Board | null> {
+	try {
+		const pds = await resolvePDS(ownerDid);
+		if (!pds) return null;
+
+		const params = new URLSearchParams({
+			repo: ownerDid,
+			collection,
+			rkey
+		});
+		const res = await fetch(
+			`${pds}/xrpc/com.atproto.repo.getRecord?${params.toString()}`
+		);
+		if (!res.ok) return null;
+
+		const data = await res.json();
+		const value = data.value as Record<string, unknown>;
+
+		return {
+			rkey,
+			did: ownerDid,
+			name: (value.name as string) ?? '',
+			description: value.description as string | undefined,
+			columns: (value.columns as Board['columns']) ?? [],
+			createdAt: (value.createdAt as string) ?? new Date().toISOString(),
+			syncStatus: 'synced'
+		};
+	} catch {
+		return null;
+	}
+}
+
+// --- Known participants management ---
+
+export async function addKnownParticipant(did: string, boardUri: string): Promise<void> {
+	const existing = await db.knownParticipants
+		.where('[did+boardUri]')
+		.equals([did, boardUri])
+		.first();
+	if (existing) return;
+
+	await db.knownParticipants.add({
+		did,
+		boardUri,
+		discoveredAt: new Date().toISOString()
+	});
+}
+
+export async function getKnownParticipants(boardUri: string): Promise<string[]> {
+	const participants = await db.knownParticipants
+		.where('boardUri')
+		.equals(boardUri)
+		.toArray();
+	return participants.map((p) => p.did);
+}
+
+export async function fetchAllKnownParticipants(boardUri: string): Promise<void> {
+	const dids = await getKnownParticipants(boardUri);
+
+	// Fetch in parallel with concurrency limit of 3
+	const concurrency = 3;
+	for (let i = 0; i < dids.length; i += concurrency) {
+		const batch = dids.slice(i, i + concurrency);
+		await Promise.allSettled(
+			batch.flatMap((did) => [fetchRemoteTasks(did, boardUri), fetchRemoteOps(did, boardUri)])
+		);
+	}
+}

--- a/src/lib/tid.ts
+++ b/src/lib/tid.ts
@@ -2,6 +2,8 @@ import { TID } from '@atproto/common-web';
 
 export const BOARD_COLLECTION = 'blue.kanban.board';
 export const TASK_COLLECTION = 'blue.kanban.task';
+export const OP_COLLECTION = 'blue.kanban.op';
+export const TRUST_COLLECTION = 'blue.kanban.trust';
 
 export function generateTID(): string {
 	return TID.nextStr();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,3 +49,84 @@ export interface TaskRecord {
 	createdAt: string;
 	updatedAt?: string;
 }
+
+// --- Op types ---
+
+export interface OpFields {
+	title?: string;
+	description?: string;
+	columnId?: string;
+	order?: number;
+}
+
+export interface Op {
+	id?: number;
+	rkey: string;
+	did: string; // DID of the op author
+	targetTaskUri: string;
+	boardUri: string;
+	fields: OpFields;
+	createdAt: string;
+	syncStatus: SyncStatus;
+}
+
+export interface OpRecord {
+	$type: 'blue.kanban.op';
+	targetTaskUri: string;
+	boardUri: string;
+	fields: OpFields;
+	createdAt: string;
+}
+
+// --- Trust types ---
+
+export interface Trust {
+	id?: number;
+	rkey: string;
+	did: string; // DID of the user who granted trust
+	trustedDid: string;
+	boardUri: string;
+	createdAt: string;
+	syncStatus: SyncStatus;
+}
+
+export interface TrustRecord {
+	$type: 'blue.kanban.trust';
+	trustedDid: string;
+	boardUri: string;
+	createdAt: string;
+}
+
+// --- Known participants ---
+
+export interface KnownParticipant {
+	id?: number;
+	did: string;
+	boardUri: string;
+	discoveredAt: string;
+	lastFetchedAt?: string;
+}
+
+// --- Materialized collaborative task view ---
+
+export interface MaterializedTask {
+	rkey: string;
+	did: string;
+	title: string;
+	description?: string;
+	columnId: string;
+	boardUri: string;
+	order: number;
+	createdAt: string;
+	updatedAt?: string;
+	sourceTask: Task;
+	appliedOps: Op[];
+	pendingOps: Op[];
+	effectiveTitle: string;
+	effectiveDescription?: string;
+	effectiveColumnId: string;
+	effectiveOrder: number;
+	ownerDid: string;
+	lastModifiedBy: string;
+	lastModifiedAt: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,16 +1,24 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { db } from '$lib/db.js';
 	import { useLiveQuery } from '$lib/db.svelte.js';
 	import { getAuth } from '$lib/auth.svelte.js';
-	import { generateTID, buildAtUri, BOARD_COLLECTION } from '$lib/tid.js';
+	import { generateTID, BOARD_COLLECTION } from '$lib/tid.js';
 	import type { Board, Column } from '$lib/types.js';
+	import { fetchRemoteBoard, addKnownParticipant } from '$lib/remote-sync.js';
+	import { grantTrust } from '$lib/trust.js';
 	import BoardCard from '$lib/components/BoardCard.svelte';
 
 	const auth = getAuth();
-	const boards = useLiveQuery<Board[]>(() => db.boards.where('did').equals(auth.did ?? '').toArray());
+
+	// Show all boards — both owned and joined
+	const boards = useLiveQuery<Board[]>(() => db.boards.toArray());
 
 	let newBoardName = $state('');
 	let creating = $state(false);
+	let joinUri = $state('');
+	let joining = $state(false);
+	let joinError = $state('');
 
 	async function createBoard(e: Event) {
 		e.preventDefault();
@@ -43,6 +51,60 @@
 			creating = false;
 		}
 	}
+
+	async function joinBoard(e: Event) {
+		e.preventDefault();
+		const uri = joinUri.trim();
+		if (!uri) return;
+
+		joinError = '';
+		joining = true;
+
+		try {
+			// Parse AT URI: at://did/collection/rkey
+			const match = uri.match(/^at:\/\/([^/]+)\/([^/]+)\/([^/]+)$/);
+			if (!match) {
+				joinError = 'Invalid AT URI format. Expected: at://did/collection/rkey';
+				return;
+			}
+
+			const [, ownerDid, collection, rkey] = match;
+			if (collection !== BOARD_COLLECTION) {
+				joinError = `Expected collection ${BOARD_COLLECTION}`;
+				return;
+			}
+
+			// Check if we already have this board
+			const existing = await db.boards.where('rkey').equals(rkey).first();
+			if (existing) {
+				goto(`/board/${rkey}`);
+				return;
+			}
+
+			// Fetch the board from the owner's PDS
+			const boardData = await fetchRemoteBoard(ownerDid, collection, rkey);
+			if (!boardData) {
+				joinError = 'Could not fetch board. Check the URI and try again.';
+				return;
+			}
+
+			await db.boards.add(boardData as Board);
+			await addKnownParticipant(ownerDid, uri);
+
+			// Auto-trust the board owner
+			if (auth.did && ownerDid !== auth.did) {
+				await grantTrust(auth.did, ownerDid, uri);
+			}
+
+			joinUri = '';
+			goto(`/board/${rkey}`);
+		} catch (err) {
+			console.error('Failed to join board:', err);
+			joinError = 'Failed to join board.';
+		} finally {
+			joining = false;
+		}
+	}
 </script>
 
 <div class="page">
@@ -63,13 +125,28 @@
 		</button>
 	</form>
 
+	<form class="join-board-form" onsubmit={joinBoard}>
+		<input
+			type="text"
+			bind:value={joinUri}
+			placeholder="Join board by AT URI (at://did/blue.kanban.board/...)"
+			disabled={joining}
+		/>
+		<button type="submit" disabled={joining || !joinUri.trim()}>
+			{joining ? 'Joining...' : 'Join Board'}
+		</button>
+	</form>
+	{#if joinError}
+		<p class="join-error">{joinError}</p>
+	{/if}
+
 	<div class="board-grid">
 		{#if boards.current && boards.current.length > 0}
 			{#each boards.current as board (board.id)}
 				<BoardCard {board} />
 			{/each}
 		{:else if boards.current}
-			<p class="empty">No boards yet. Create one above to get started.</p>
+			<p class="empty">No boards yet. Create one above or join one with an AT URI.</p>
 		{/if}
 	</div>
 </div>
@@ -91,13 +168,19 @@
 		font-weight: 600;
 	}
 
-	.create-board-form {
+	.create-board-form,
+	.join-board-form {
 		display: flex;
 		gap: 0.5rem;
-		margin-bottom: 2rem;
+		margin-bottom: 0.75rem;
 	}
 
-	.create-board-form input {
+	.join-board-form {
+		margin-bottom: 1.5rem;
+	}
+
+	.create-board-form input,
+	.join-board-form input {
 		flex: 1;
 		padding: 0.625rem 0.75rem;
 		border: 1px solid var(--color-border);
@@ -107,13 +190,15 @@
 		color: var(--color-text);
 	}
 
-	.create-board-form input:focus {
+	.create-board-form input:focus,
+	.join-board-form input:focus {
 		outline: none;
 		border-color: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-alpha);
 	}
 
-	.create-board-form button {
+	.create-board-form button,
+	.join-board-form button {
 		padding: 0.625rem 1.25rem;
 		background: var(--color-primary);
 		color: white;
@@ -126,13 +211,21 @@
 		transition: background 0.15s;
 	}
 
-	.create-board-form button:hover:not(:disabled) {
+	.create-board-form button:hover:not(:disabled),
+	.join-board-form button:hover:not(:disabled) {
 		background: var(--color-primary-hover);
 	}
 
-	.create-board-form button:disabled {
+	.create-board-form button:disabled,
+	.join-board-form button:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+	}
+
+	.join-error {
+		color: var(--color-error);
+		font-size: 0.8125rem;
+		margin: -0.5rem 0 1rem;
 	}
 
 	.board-grid {

--- a/src/routes/board/[id]/+page.svelte
+++ b/src/routes/board/[id]/+page.svelte
@@ -1,45 +1,92 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
+	import { onDestroy } from 'svelte';
 	import { db } from '$lib/db.js';
 	import { useLiveQuery } from '$lib/db.svelte.js';
 	import { getAuth } from '$lib/auth.svelte.js';
-	import { buildAtUri, BOARD_COLLECTION } from '$lib/tid.js';
-	import type { Board, Task } from '$lib/types.js';
+	import { buildAtUri, BOARD_COLLECTION, TASK_COLLECTION, OP_COLLECTION } from '$lib/tid.js';
+	import { materializeTasks } from '$lib/materialize.js';
+	import {
+		JetstreamClient,
+		loadJetstreamCursor,
+		processJetstreamEvent
+	} from '$lib/jetstream.js';
+	import { fetchAllKnownParticipants, addKnownParticipant } from '$lib/remote-sync.js';
+	import type { Board, Task, Op, Trust, MaterializedTask } from '$lib/types.js';
 	import Column from '$lib/components/Column.svelte';
 	import BoardSettingsModal from '$lib/components/BoardSettingsModal.svelte';
+	import ProposalPanel from '$lib/components/ProposalPanel.svelte';
 
 	const auth = getAuth();
 
 	const rkey = $derived($page.params.id);
 
-	const board = useLiveQuery<Board | undefined>(() =>
-		db.boards.where('rkey').equals(rkey).first()
-	);
+	// The board can be owned by anyone — find it by rkey
+	const board = useLiveQuery<Board | undefined>(() => {
+		if (!rkey) return undefined;
+		return db.boards.where('rkey').equals(rkey).first();
+	});
 
+	// Build the boardUri from the board's own DID (not necessarily the current user)
 	const boardUri = $derived(
-		board.current && auth.did
-			? buildAtUri(auth.did, BOARD_COLLECTION, board.current.rkey)
-			: ''
+		board.current ? buildAtUri(board.current.did, BOARD_COLLECTION, board.current.rkey) : ''
 	);
 
-	const tasks = useLiveQuery<Task[]>(() => {
+	// All tasks for this board from ANY user
+	const allTasks = useLiveQuery<Task[]>(() => {
 		if (!boardUri) return [];
 		return db.tasks.where('boardUri').equals(boardUri).toArray();
 	});
 
+	// All ops for this board from ANY user
+	const allOps = useLiveQuery<Op[]>(() => {
+		if (!boardUri) return [];
+		return db.ops.where('boardUri').equals(boardUri).toArray();
+	});
+
+	// Trust records from the current user for this board
+	const trusts = useLiveQuery<Trust[]>(() => {
+		if (!boardUri || !auth.did) return [];
+		return db.trusts
+			.where('did')
+			.equals(auth.did)
+			.filter((t) => t.boardUri === boardUri)
+			.toArray();
+	});
+
+	// Materialized view with LWW merge
+	const materializedTasks = $derived.by(() => {
+		if (!allTasks.current || !allOps.current || !auth.did) return [];
+		const trustedDids = new Set((trusts.current ?? []).map((t) => t.trustedDid));
+		return materializeTasks(allTasks.current, allOps.current, trustedDids, auth.did);
+	});
+
+	// Pending proposals from untrusted users
+	const pendingProposals = $derived(materializedTasks.flatMap((t) => t.pendingOps));
+
+	// Tasks from untrusted DIDs (these don't show on the board until trusted)
+	const untrustedTasks = $derived.by(() => {
+		const trustedDids = new Set((trusts.current ?? []).map((t) => t.trustedDid));
+		return (allTasks.current ?? []).filter(
+			(t) => t.did !== auth.did && !trustedDids.has(t.did)
+		);
+	});
+
+	// Group materialized tasks by effective column
 	const tasksByColumn = $derived.by(() => {
-		const map = new Map<string, Task[]>();
+		const map = new Map<string, MaterializedTask[]>();
 		if (!board.current) return map;
 		for (const col of board.current.columns) {
 			map.set(col.id, []);
 		}
-		if (tasks.current) {
-			for (const task of tasks.current) {
-				const list = map.get(task.columnId);
-				if (list) {
-					list.push(task);
-				}
+		for (const task of materializedTasks) {
+			// Only show tasks from trusted users + self
+			const trustedDids = new Set((trusts.current ?? []).map((t) => t.trustedDid));
+			if (task.ownerDid !== auth.did && !trustedDids.has(task.ownerDid)) continue;
+			const list = map.get(task.effectiveColumnId);
+			if (list) {
+				list.push(task);
 			}
 		}
 		return map;
@@ -50,17 +97,71 @@
 	);
 
 	let showSettings = $state(false);
+	let showProposals = $state(false);
+
+	// --- Jetstream lifecycle ---
+	let jetstreamClient: JetstreamClient | null = null;
+
+	$effect(() => {
+		if (!boardUri) return;
+
+		const watchedBoards = new Set([boardUri]);
+
+		// Cold start: fetch from known participants
+		fetchAllKnownParticipants(boardUri).catch(console.error);
+
+		// Start Jetstream
+		loadJetstreamCursor().then((cursor) => {
+			jetstreamClient = new JetstreamClient({
+				wantedCollections: [TASK_COLLECTION, OP_COLLECTION],
+				cursor,
+				onEvent: async (event) => {
+					// Don't process our own events
+					if (event.did === auth.did) return;
+					const relevantDid = await processJetstreamEvent(event, watchedBoards);
+					if (relevantDid) {
+						addKnownParticipant(relevantDid, boardUri).catch(console.error);
+					}
+				},
+				onConnect: () => {
+					console.log('Jetstream connected');
+				},
+				onError: (err) => {
+					console.warn('Jetstream error:', err);
+				}
+			});
+			jetstreamClient.connect();
+		});
+
+		return () => {
+			jetstreamClient?.disconnect();
+			jetstreamClient = null;
+		};
+	});
+
+	const isBoardOwner = $derived(board.current?.did === auth.did);
+
+	let shareCopied = $state(false);
+	async function shareBoardUri() {
+		try {
+			await navigator.clipboard.writeText(boardUri);
+			shareCopied = true;
+			setTimeout(() => (shareCopied = false), 2000);
+		} catch {
+			// Fallback: prompt with the URI
+			window.prompt('Copy this board URI to share:', boardUri);
+		}
+	}
 
 	async function deleteBoard() {
-		if (!board.current?.id) return;
+		if (!board.current?.id || !isBoardOwner) return;
 		if (!confirm('Delete this board and all its tasks?')) return;
 
 		const boardId = board.current.id;
 		const uri = boardUri;
 
-		// Delete all tasks for this board
 		await db.tasks.where('boardUri').equals(uri).delete();
-		// Delete the board
+		await db.ops.where('boardUri').equals(uri).delete();
 		await db.boards.delete(boardId);
 
 		goto('/');
@@ -74,12 +175,28 @@
 				<a href="/" class="back-link">Boards</a>
 				<span class="separator">/</span>
 				<h2>{board.current.name}</h2>
+				{#if !isBoardOwner}
+					<span class="shared-badge">Shared</span>
+				{/if}
 			</div>
 			<div class="board-header-right">
-				<button class="settings-btn" onclick={() => (showSettings = true)}>
-					Settings
+				{#if pendingProposals.length > 0 || untrustedTasks.length > 0}
+					<button class="proposals-btn" onclick={() => (showProposals = true)}>
+						Proposals
+						<span class="badge">
+							{pendingProposals.length + untrustedTasks.length}
+						</span>
+					</button>
+				{/if}
+				<button class="share-btn" onclick={shareBoardUri}>
+					{shareCopied ? 'Copied!' : 'Share'}
 				</button>
-				<button class="delete-btn" onclick={deleteBoard}>Delete</button>
+				{#if isBoardOwner}
+					<button class="settings-btn" onclick={() => (showSettings = true)}>
+						Settings
+					</button>
+					<button class="delete-btn" onclick={deleteBoard}>Delete</button>
+				{/if}
 			</div>
 		</div>
 
@@ -95,8 +212,17 @@
 		</div>
 	</div>
 
-	{#if showSettings}
+	{#if showSettings && isBoardOwner}
 		<BoardSettingsModal board={board.current} onclose={() => (showSettings = false)} />
+	{/if}
+
+	{#if showProposals}
+		<ProposalPanel
+			proposals={pendingProposals}
+			{untrustedTasks}
+			{boardUri}
+			onclose={() => (showProposals = false)}
+		/>
 	{/if}
 {:else}
 	<div class="not-found">
@@ -142,13 +268,23 @@
 		font-weight: 600;
 	}
 
+	.shared-badge {
+		font-size: 0.6875rem;
+		background: var(--color-primary-alpha, rgba(0, 102, 204, 0.1));
+		color: var(--color-primary);
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-sm);
+		font-weight: 500;
+	}
+
 	.board-header-right {
 		display: flex;
 		gap: 0.5rem;
 	}
 
 	.settings-btn,
-	.delete-btn {
+	.delete-btn,
+	.share-btn {
 		padding: 0.375rem 0.75rem;
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius-md);
@@ -161,7 +297,8 @@
 			color 0.15s;
 	}
 
-	.settings-btn:hover {
+	.settings-btn:hover,
+	.share-btn:hover {
 		background: var(--color-bg);
 		color: var(--color-text);
 	}
@@ -170,6 +307,36 @@
 		background: var(--color-error-bg);
 		color: var(--color-error);
 		border-color: var(--color-error);
+	}
+
+	.proposals-btn {
+		padding: 0.375rem 0.75rem;
+		border: 1px solid var(--color-warning);
+		border-radius: var(--radius-md);
+		font-size: 0.8125rem;
+		cursor: pointer;
+		background: var(--color-surface);
+		color: var(--color-warning);
+		font-weight: 500;
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		transition: background 0.15s;
+	}
+
+	.proposals-btn:hover {
+		background: var(--color-bg);
+	}
+
+	.badge {
+		font-size: 0.6875rem;
+		background: var(--color-warning);
+		color: white;
+		padding: 0 0.375rem;
+		border-radius: var(--radius-sm);
+		font-weight: 600;
+		min-width: 1rem;
+		text-align: center;
 	}
 
 	.columns-container {

--- a/static/client-metadata.json
+++ b/static/client-metadata.json
@@ -3,7 +3,7 @@
   "client_name": "AT Kanban",
   "client_uri": "https://at-kanban.example.com",
   "redirect_uris": ["https://at-kanban.example.com/"],
-  "scope": "atproto repo:blue.kanban.board repo:blue.kanban.task",
+  "scope": "atproto repo:blue.kanban.board repo:blue.kanban.task repo:blue.kanban.op repo:blue.kanban.trust",
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",


### PR DESCRIPTION
## Summary

Implements multi-user collaborative kanban boards where any user can add tasks to shared boards via AT URI. Non-owned tasks are managed through an operations log (ops) with Jetstream integration for real-time discovery. A trust system controls which users' contributions auto-apply vs appear as proposals.

## Key Features

- **Multi-user boards**: Share boards by AT URI; anyone can add tasks
- **Operations log**: Mutations to non-owned tasks recorded as ops in author's repo
- **Trust system**: Explicitly trust editors; their changes auto-apply
- **LWW conflict resolution**: Per-field resolution by timestamp
- **Jetstream integration**: Real-time discovery of tasks and ops
- **Board owner auto-trust**: Joining a board auto-trusts its creator
- **Proposals UI**: Review pending changes from untrusted users before granting trust

## Technical Details

New lexicons: `blue.kanban.op` (propose task mutations), `blue.kanban.trust` (grant editor trust)
New modules: ops, trust, materialize (LWW engine), jetstream (WebSocket client), remote-sync (DID resolution)
Updated UI components: board page (multi-user view), Column/TaskCard (op support), ProposalPanel (new), AuthorBadge (new)
Database migration: v2 schema with ops, trusts, knownParticipants tables