### PR TITLE
Display Bluesky profile info instead of raw DIDs

### DIFF
--- a/src/lib/components/ProposalPanel.svelte
+++ b/src/lib/components/ProposalPanel.svelte
@@ -2,6 +2,7 @@
 	import type { Op, Task } from '$lib/types.js';
 	import { grantTrust } from '$lib/trust.js';
 	import { getAuth } from '$lib/auth.svelte.js';
+	import AuthorBadge from './AuthorBadge.svelte';
 
 	let {
 		proposals,
@@ -49,10 +50,6 @@
 		if (op.fields.order !== undefined) parts.push('order');
 		return parts.length > 0 ? `Change ${parts.join(', ')}` : 'Unknown change';
 	}
-
-	function shortDid(did: string): string {
-		return did.length > 24 ? did.slice(0, 14) + '...' + did.slice(-6) : did;
-	}
 </script>
 
 <div class="panel-backdrop" onclick={onclose} role="presentation">
@@ -69,7 +66,7 @@
 			{#each [...groupedByAuthor.entries()] as [authorDid, { ops, tasks }]}
 				<div class="author-section">
 					<div class="author-header">
-						<span class="author-did" title={authorDid}>{shortDid(authorDid)}</span>
+						<AuthorBadge did={authorDid} />
 						<button class="trust-btn" onclick={() => trustUser(authorDid)}>
 							Trust Editor
 						</button>
@@ -161,12 +158,6 @@
 		justify-content: space-between;
 		gap: 0.5rem;
 		margin-bottom: 0.5rem;
-	}
-
-	.author-did {
-		font-family: monospace;
-		font-size: 0.6875rem;
-		color: var(--color-text-secondary);
 	}
 
 	.subsection-label {

--- a/src/lib/profile-cache.svelte.ts
+++ b/src/lib/profile-cache.svelte.ts
@@ -1,0 +1,93 @@
+interface ProfileData {
+	handle: string;
+	displayName?: string;
+	avatar?: string;
+	fetchedAt: number;
+}
+
+interface ProfileState {
+	loading: boolean;
+	data: ProfileData | null;
+	error: boolean;
+}
+
+const PUBLIC_API = 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile';
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+const DEFAULT_STATE: ProfileState = { loading: false, data: null, error: false };
+
+// Module-level reactive cache
+let profiles = $state<Record<string, ProfileState>>({});
+
+// In-flight request deduplication
+const inflight = new Map<string, Promise<void>>();
+
+async function fetchProfile(did: string): Promise<void> {
+	if (inflight.has(did)) return;
+
+	const promise = (async () => {
+		try {
+			const res = await fetch(`${PUBLIC_API}?actor=${encodeURIComponent(did)}`);
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const data = await res.json();
+
+			profiles[did] = {
+				loading: false,
+				error: false,
+				data: {
+					handle: data.handle,
+					displayName: data.displayName || undefined,
+					avatar: data.avatar || undefined,
+					fetchedAt: Date.now()
+				}
+			};
+		} catch {
+			profiles[did] = {
+				loading: false,
+				error: true,
+				data: null
+			};
+		} finally {
+			inflight.delete(did);
+		}
+	})();
+
+	inflight.set(did, promise);
+}
+
+/**
+ * Pure read — safe to call inside $derived.
+ * Returns the current cached profile state without side effects.
+ */
+export function getProfile(did: string): ProfileState {
+	return profiles[did] ?? DEFAULT_STATE;
+}
+
+/**
+ * Side-effectful — call from $effect to trigger fetching.
+ * Starts a fetch if the profile is missing, expired, or errored.
+ */
+export function ensureProfile(did: string): void {
+	const cached = profiles[did];
+
+	// Already valid and not expired
+	if (cached?.data && Date.now() - cached.data.fetchedAt < TTL_MS) return;
+
+	// Already loading
+	if (cached?.loading) return;
+
+	// Expired but have stale data — keep showing stale while refetching
+	if (cached?.data) {
+		profiles[did] = { loading: true, data: cached.data, error: false };
+		fetchProfile(did);
+		return;
+	}
+
+	// No data at all — start fresh fetch
+	profiles[did] = { loading: true, data: null, error: false };
+	fetchProfile(did);
+}
+
+export function shortDid(did: string): string {
+	return did.length > 24 ? did.slice(0, 14) + '...' + did.slice(-6) : did;
+}


### PR DESCRIPTION
## Summary

Replace raw DID strings with Bluesky profile information (avatar, handle, displayName) throughout the UI. Users now see human-readable handles and profile pictures instead of truncated DIDs in task cards, headers, and proposal panels.

## Implementation

- Created `profile-cache.svelte.ts`: reactive profile resolver using the public Bluesky API with in-memory caching (10-min TTL) and request deduplication
- Updated `AuthorBadge.svelte`: displays avatar circle + handle, falls back to truncated DID while loading
- Updated `+layout.svelte`: header now shows current user's avatar + handle instead of raw DID
- Updated `ProposalPanel.svelte`: replaced inline DID display with AuthorBadge component

Uses Svelte 5 runes pattern: `$effect` triggers profile fetching, `$derived` reads cache for reactivity.

## Test Plan

- Log in and verify header shows avatar + handle
- Create tasks and verify task cards show author's avatar + handle
- Open proposal panel and verify author DIDs are resolved to handles
- Hover over any profile badge to see full DID in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)