### PR TITLE
Fix Jetstream backfill and cursor handling

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,4 +22,12 @@ db.version(2).stores({
 	knownParticipants: '++id, did, boardUri, [did+boardUri]'
 });
 
+db.version(3).stores({
+	boards: '++id, rkey, did, syncStatus',
+	tasks: '++id, rkey, did, columnId, boardUri, order, syncStatus, [did+rkey]',
+	ops: '++id, rkey, did, targetTaskUri, boardUri, createdAt, syncStatus, [did+rkey]',
+	trusts: '++id, rkey, did, trustedDid, boardUri, syncStatus, [did+boardUri+trustedDid], [did+rkey]',
+	knownParticipants: '++id, did, boardUri, [did+boardUri]'
+});
+
 export { db };


### PR DESCRIPTION
## Summary
- **Stale cursor detection** (48h threshold): Prevents silent data loss when cursors outlive Jetstream's ~72h retention window
- **PDS backfill on stale cursor**: Automatically fetches current state when cursor is discarded
- **beforeunload listener**: Ensures cursor is persisted even on abrupt tab close
- **Reconnect backfill**: Re-fetches known participants after WebSocket reconnections to catch missed events
- **Trust collection real-time**: Added TRUST_COLLECTION to Jetstream subscriptions
- **Removed board filtering**: Events for all boards are stored to prevent cursor gaps for unseen boards

## Test Plan
- Open board, close tab, reopen — verify changes from other users are there
- Set stale cursor in localStorage, reload — verify PDS backfill is triggered
- Simulate network disconnect, make changes, reconnect — verify catch-up happens
- Navigate between boards — verify cross-board changes are visible