### PR TITLE
Reduce PDS background sync interval to 5 seconds

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -363,7 +363,7 @@ export function startBackgroundSync(agent: Agent, did: string): void {
 	stopBackgroundSync();
 	syncInterval = setInterval(() => {
 		syncPendingToPDS(agent, did).catch(console.error);
-	}, 30_000);
+	}, 5_000);
 	// Also run immediately
 	syncPendingToPDS(agent, did).catch(console.error);
 }


### PR DESCRIPTION
## Summary
Speeds up syncing of pending changes to the PDS by reducing the background sync interval from 30 seconds to 5 seconds, providing faster user feedback when creating or updating boards and tasks.

## Test plan
- Verify that pending changes sync to PDS within 5 seconds
- Check that background sync continues to work correctly with the new interval

🤖 Generated with Claude Code