### PR TITLE
Add markdown rendering to card descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
         "codemirror": "^6.0.2",
-        "dexie": "^4.0.11"
+        "dexie": "^4.0.11",
+        "marked": "^17.0.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.8",
@@ -2160,6 +2161,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "codemirror": "^6.0.2",
-    "dexie": "^4.0.11"
+    "dexie": "^4.0.11",
+    "marked": "^17.0.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.8",

--- a/src/lib/components/TaskCard.svelte
+++ b/src/lib/components/TaskCard.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 	import type { MaterializedTask } from '$lib/types.js';
+	import { Marked } from 'marked';
 	import AuthorBadge from './AuthorBadge.svelte';
+
+	const marked = new Marked({
+		renderer: {
+			html({ text }: { text: string }) {
+				return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			}
+		}
+	});
 
 	let {
 		task,
@@ -13,6 +22,10 @@
 		pending?: boolean;
 		onedit: (task: MaterializedTask) => void;
 	} = $props();
+
+	const renderedDescription = $derived(
+		task.effectiveDescription ? (marked.parse(task.effectiveDescription) as string) : ''
+	);
 
 	const isOwned = $derived(task.ownerDid === currentUserDid);
 
@@ -60,7 +73,7 @@
 	{/if}
 	<div class="task-title">{task.effectiveTitle}</div>
 	{#if task.effectiveDescription}
-		<div class="task-desc">{task.effectiveDescription}</div>
+		<div class="task-desc">{@html renderedDescription}</div>
 	{/if}
 	<div class="task-meta">
 		<AuthorBadge did={task.ownerDid} isCurrentUser={isOwned} />
@@ -137,12 +150,74 @@
 	.task-desc {
 		margin-top: 0.25rem;
 		font-size: 0.75rem;
+		line-height: 1.4;
 		color: var(--color-text-secondary);
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
+		max-height: calc(7 * 1.4em);
 		overflow: hidden;
 		word-break: break-word;
+		-webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+		mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+	}
+
+	.task-desc :global(p),
+	.task-desc :global(h1),
+	.task-desc :global(h2),
+	.task-desc :global(h3),
+	.task-desc :global(h4),
+	.task-desc :global(h5),
+	.task-desc :global(h6) {
+		margin: 0 0 0.25em;
+	}
+
+	.task-desc :global(h1),
+	.task-desc :global(h2),
+	.task-desc :global(h3),
+	.task-desc :global(h4),
+	.task-desc :global(h5),
+	.task-desc :global(h6) {
+		font-size: 0.8125rem;
+		font-weight: 600;
+	}
+
+	.task-desc :global(ul),
+	.task-desc :global(ol) {
+		margin: 0 0 0.25em;
+		padding-left: 1.25em;
+	}
+
+	.task-desc :global(li) {
+		margin: 0;
+	}
+
+	.task-desc :global(code) {
+		font-size: 0.6875rem;
+		background: var(--color-border-light);
+		padding: 0.1em 0.3em;
+		border-radius: var(--radius-sm);
+	}
+
+	.task-desc :global(pre) {
+		margin: 0.25em 0;
+		padding: 0.375em 0.5em;
+		background: var(--color-border-light);
+		border-radius: var(--radius-sm);
+		overflow: hidden;
+	}
+
+	.task-desc :global(pre code) {
+		background: none;
+		padding: 0;
+	}
+
+	.task-desc :global(blockquote) {
+		margin: 0.25em 0;
+		padding-left: 0.5em;
+		border-left: 2px solid var(--color-border);
+		color: var(--color-text-secondary);
+	}
+
+	.task-desc :global(:last-child) {
+		margin-bottom: 0;
 	}
 
 	.task-meta {


### PR DESCRIPTION
## Summary
- Cards now display description previews rendered from markdown
- Shows up to ~7 lines with a fade-out gradient effect to indicate overflow
- Raw HTML in descriptions is safely escaped to prevent XSS

## Test plan
- Create/edit cards with markdown descriptions (headers, bold, lists, code)
- Verify markdown renders correctly on cards with compact formatting
- Verify raw HTML tags are not rendered as HTML
- Click card to confirm edit modal still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)