### PR TITLE
Sanitize card descriptions with DOMPurify to prevent XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "@codemirror/language-data": "^6.5.2",
         "codemirror": "^6.0.2",
         "dexie": "^4.0.11",
+        "dompurify": "^3.3.1",
         "marked": "^17.0.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/kit": "^2.15.2",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@types/dompurify": "^3.0.5",
         "svelte": "^5.16.6",
         "svelte-check": "^4.1.4",
         "typescript": "^5.7.3",
@@ -1858,11 +1860,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
@@ -2012,6 +2031,15 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.3.0.tgz",
       "integrity": "sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "@codemirror/language-data": "^6.5.2",
     "codemirror": "^6.0.2",
     "dexie": "^4.0.11",
+    "dompurify": "^3.3.1",
     "marked": "^17.0.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.15.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@types/dompurify": "^3.0.5",
     "svelte": "^5.16.6",
     "svelte-check": "^4.1.4",
     "typescript": "^5.7.3",

--- a/src/lib/components/TaskCard.svelte
+++ b/src/lib/components/TaskCard.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import type { MaterializedTask } from '$lib/types.js';
 	import { Marked } from 'marked';
+	import DOMPurify from 'dompurify';
 	import AuthorBadge from './AuthorBadge.svelte';
 
-	const marked = new Marked({
-		renderer: {
-			html({ text }: { text: string }) {
-				return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-			}
+	const marked = new Marked();
+
+	DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+		if (node.tagName === 'A') {
+			node.setAttribute('rel', 'noopener noreferrer');
 		}
 	});
 
@@ -24,7 +25,9 @@
 	} = $props();
 
 	const renderedDescription = $derived(
-		task.effectiveDescription ? (marked.parse(task.effectiveDescription) as string) : ''
+		task.effectiveDescription
+			? DOMPurify.sanitize(marked.parse(task.effectiveDescription) as string)
+			: ''
 	);
 
 	const isOwned = $derived(task.ownerDid === currentUserDid);


### PR DESCRIPTION
## Summary

Fixes a critical XSS vulnerability in card descriptions where `javascript:` URLs in markdown links could execute in viewers' browsers. All descriptions are now sanitized through DOMPurify after markdown parsing.

- Blocks `javascript:`, `data:` URLs and event handlers in markdown
- Strips raw HTML/script tags that bypass markdown parsing
- Adds `rel="noopener noreferrer"` to all links from untrusted AT Protocol sources

## Test plan

1. Create a card with description: `[click me](javascript:alert(1))`
2. Verify the link is stripped (renders as plain text "click me")
3. Verify normal markdown links like `[test](https://example.com)` still work
4. Verify `<script>alert(1)</script>` renders as escaped text

🤖 Generated with [Claude Code](https://claude.com/claude-code)