### PR TITLE
Fix logout not clearing persisted OAuth session

### DIFF
--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -84,15 +84,14 @@ export async function login(handle: string): Promise<void> {
 }
 
 export async function logout(): Promise<void> {
+	const sub = did;
 	agent = null;
 	did = null;
-	// Clear any stored sessions by re-initializing
-	if (oauthClient) {
+	if (oauthClient && sub) {
 		try {
-			// The BrowserOAuthClient doesn't have a direct logout method on the client,
-			// but clearing the state is sufficient for the UI
+			await oauthClient.revoke(sub);
 		} catch {
-			// Ignore cleanup errors
+			// Ignore revocation errors — state is already cleared
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Logout now properly revokes the OAuth session token, preventing automatic re-login after logout on page refresh. The logout function previously only cleared local state, allowing the OAuth client to restore the persisted session from IndexedDB.

## Changes
- Call `oauthClient.revoke(sub)` in the logout function
- Save the `did` before clearing local state so revocation can use it
- Proper error handling for revocation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)