### PR TITLE
readme: Format for better plaintext legibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # Skyboard
 
-A collaborative kanban board built on [AT Protocol](https://atproto.com/) (Bluesky's decentralized data layer). Each user's data lives in their own AT Protocol repository. An **appview** server aggregates board data and provides real-time updates, while writes go directly to each user's PDS.
+A collaborative kanban board built on [AT Protocol] (Bluesky's decentralized
+data layer). Each user's data lives in their own AT Protocol repository. An
+**appview** server aggregates board data and provides real-time updates, while
+writes go directly to each user's PDS.
+
+[AT Protocol]: https://atproto.com/
 
 ## How it works
 
-Users sign in with their Bluesky account and create boards. Each board gets an AT URI (e.g. `at://did:plc:abc.../dev.skyboard.board/3k...`) that can be shared with collaborators. The browser fetches the full board state from the appview in a single request and subscribes to real-time updates via WebSocket.
+Users sign in with their Bluesky account and create boards. Each board gets an
+AT URI (e.g. `at://did:plc:abc.../dev.skyboard.board/3k...`) that can be shared
+with collaborators. The browser fetches the full board state from the appview in
+a single request and subscribes to real-time updates via WebSocket.
 
-All data is stored locally in IndexedDB (via Dexie). Writes (creating tasks, editing, commenting) go to Dexie first, then background sync pushes them to the user's PDS. The appview picks up PDS commits via Jetstream and notifies connected clients.
+All data is stored locally in IndexedDB (via Dexie). Writes (creating tasks,
+editing, commenting) go to Dexie first, then background sync pushes them to
+the user's PDS. The appview picks up PDS commits via Jetstream and notifies
+connected clients.
 
 ## Architecture
 
-The appview sits between clients and the AT Protocol network. It subscribes to Jetstream for real-time ingestion and backfills from PDS endpoints on demand, caching everything in SQLite. Clients read from the appview and write to their own PDS.
+The appview sits between clients and the AT Protocol network. It subscribes to
+Jetstream for real-time ingestion and backfills from PDS endpoints on demand,
+caching everything in SQLite. Clients read from the appview and write to their
+own PDS.
 
 ```
  ┌─ Browser (per user) ────────────────────────────────────────────┐
@@ -59,7 +73,10 @@ The appview sits between clients and the AT Protocol network. It subscribes to J
 
 ### Multi-user coordination
 
-When multiple users collaborate on a board, each writes only to their own PDS. The appview aggregates records from all participants — the board owner's PDS has board configuration and trust grants, while tasks and ops can live in any participant's PDS. Ops reference tasks in any repo via AT URI.
+When multiple users collaborate on a board, each writes only to their own PDS.
+The appview aggregates records from all participants — the board owner's PDS
+has board configuration and trust grants, while tasks and ops can live in any
+participant's PDS. Ops reference tasks in any repo via AT URI.
 
 ```
  ┌─ Alice's PDS ─────────────┐  ┌─ Bob's PDS ────────────┐  ┌─ Carol's PDS ──────────┐
@@ -112,14 +129,24 @@ When multiple users collaborate on a board, each writes only to their own PDS. T
 
 ## Data model
 
-There are four record types, each stored as AT Protocol records in the user's repo:
+There are four record types, each stored as AT Protocol records in the user's
+repo:
 
-- **Board** (`dev.skyboard.board`) — name, description, column configuration, and permission rules. Owned by whoever created it.
-- **Task** (`dev.skyboard.task`) — a card on the board with title, description, column, and fractional index position. Owned by whoever created it. Write-once: the record captures the initial state at creation and is never updated directly.
-- **Op** (`dev.skyboard.op`) — an edit to any task, including your own. Contains partial field updates (title, description, columnId, position) and targets a task by AT URI.
-- **Trust** (`dev.skyboard.trust`) — a per-board grant allowing another user's ops to take effect on your view of the board.
+- **Board** (`dev.skyboard.board`) — name, description, column configuration,
+  and permission rules. Owned by whoever created it.
+- **Task** (`dev.skyboard.task`) — a card on the board with title, description,
+  column, and fractional index position. Owned by whoever created it.
+  Write-once: the record captures the initial state at creation and is never
+  updated directly.
+- **Op** (`dev.skyboard.op`) — an edit to any task, including your own. Contains
+  partial field updates (title, description, columnId, position) and targets a
+  task by AT URI.
+- **Trust** (`dev.skyboard.trust`) — a per-board grant allowing another user's
+  ops to take effect on your view of the board.
 
-Here's how two users coordinate on a single board. Each user can only write records to their own PDS — cross-user edits work by writing Ops that reference another user's Task by AT URI.
+Here's how two users coordinate on a single board. Each user can only write
+records to their own PDS — cross-user edits work by writing Ops that reference
+another user's Task by AT URI.
 
 ```
   Alice's PDS (did:plc:alice)              Bob's PDS (did:plc:bob)
@@ -171,33 +198,62 @@ Here's how two users coordinate on a single board. Each user can only write reco
 
 ### Why ops?
 
-You can only write to your own AT Protocol repo. If you want to move or edit someone else's card, you publish an Op record to your repo proposing the change. The board owner (and other participants who trust you) will see your edit applied; those who don't trust you will see it as a pending proposal.
+You can only write to your own AT Protocol repo. If you want to move or edit
+someone else's card, you publish an Op record to your repo proposing the change.
+The board owner (and other participants who trust you) will see your edit
+applied; those who don't trust you will see it as a pending proposal.
 
-All task edits go through ops — even edits to your own tasks. This ensures per-field LWW timestamps are always correct. A single `updatedAt` on the task record can't distinguish which fields actually changed, so a direct write to one field (e.g. title) would poison the timestamp for all fields, silently reverting concurrent ops on other fields (e.g. a collaborator's column move). By routing all edits through ops, each field change carries its own timestamp and LWW resolves correctly.
+All task edits go through ops — even edits to your own tasks. This ensures
+per-field LWW timestamps are always correct. A single `updatedAt` on the task
+record can't distinguish which fields actually changed, so a direct write to one
+field (e.g. title) would poison the timestamp for all fields, silently reverting
+concurrent ops on other fields (e.g. a collaborator's column move). By routing
+all edits through ops, each field change carries its own timestamp and LWW
+resolves correctly.
 
 ## Conflict resolution
 
-Edits are resolved using **per-field last-writer-wins** (LWW) with ISO 8601 timestamps. Each mutable field — `title`, `description`, `columnId`, `position` — is independently resolved. The value with the latest timestamp wins.
+Edits are resolved using **per-field last-writer-wins** (LWW) with ISO 8601
+timestamps. Each mutable field — `title`, `description`, `columnId`, `position`
+— is independently resolved. The value with the latest timestamp wins.
 
-This is formally an **LWW-Register Map**, a well-known CRDT. The merge function is commutative, associative, and idempotent, so all clients converge to the same state regardless of the order they receive operations.
+This is formally an **LWW-Register Map**, a well-known CRDT. The merge function
+is commutative, associative, and idempotent, so all clients converge to the same
+state regardless of the order they receive operations.
 
 ### Fractional indexing
 
-Task ordering within columns uses [fractional indexing](https://www.npmjs.com/package/fractional-indexing) — each task has a `position` string that sorts lexicographically. Moving a task generates a new position string between its neighbors, so **only the moved task is ever updated**. This is critical for the distributed model: since you can only write to your own repo, integer-based ordering (which requires renumbering multiple tasks) would fail when moving other users' cards. With fractional indexing, a single op with the new position is sufficient.
+Task ordering within columns uses [fractional indexing] — each task has a
+`position` string that sorts lexicographically. Moving a task generates a
+new position string between its neighbors, so **only the moved task is ever
+updated**. This is critical for the distributed model: since you can only write
+to your own repo, integer-based ordering (which requires renumbering multiple
+tasks) would fail when moving other users' cards. With fractional indexing, a
+single op with the new position is sufficient.
 
-A trust layer sits on top: only ops from the task owner, the current user, or explicitly trusted users are merged into the effective board state. Untrusted ops are stored but shown separately in a Proposals panel. Once trust converges (all participants agree on who to trust), the underlying LWW properties guarantee full convergence.
+[fractional indexing]: https://www.npmjs.com/package/fractional-indexing
+
+A trust layer sits on top: only ops from the task owner, the current user, or
+explicitly trusted users are merged into the effective board state. Untrusted
+ops are stored but shown separately in a Proposals panel. Once trust converges
+(all participants agree on who to trust), the underlying LWW properties
+guarantee full convergence.
 
 ## Trust system
 
 - The board owner's edits are always trusted on their own board.
 - Your own ops are always applied in your local view.
-- Other users require an explicit trust grant (per-board) before their ops affect your view.
+- Other users require an explicit trust grant (per-board) before their ops
+  affect your view.
 - Joining a board auto-trusts the board owner.
-- Untrusted ops and tasks from unknown users appear in the Proposals panel, where you can review them and grant trust.
+- Untrusted ops and tasks from unknown users appear in the Proposals panel,
+  where you can review them and grant trust.
 
 ## Board permissions
 
-On top of the trust system, board authors can configure fine-grained permission rules that control what operations are allowed and by whom. Permissions are stored on the board record and enforced during operation materialization.
+On top of the trust system, board authors can configure fine-grained permission
+rules that control what operations are allowed and by whom. Permissions are
+stored on the board record and enforced during operation materialization.
 
 ### Operations
 
@@ -214,16 +270,21 @@ Five operation types can be independently controlled:
 Each operation is assigned one of three scopes:
 
 - **author_only** — only the board owner can perform the operation
-- **trusted** — the board owner and explicitly trusted users (default for all operations)
+- **trusted** — the board owner and explicitly trusted users (default for all
+  operations)
 - **anyone** — any user can perform the operation
 
 ### Per-column rules
 
-Permission rules can optionally be scoped to specific columns, allowing patterns like "anyone can create tasks in the Inbox column, but only trusted users can move tasks to Done."
+Permission rules can optionally be scoped to specific columns, allowing patterns
+like "anyone can create tasks in the Inbox column, but only trusted users can
+move tasks to Done."
 
 ### Pending operations
 
-When a user performs an action they don't have full permission for (e.g. scope is `trusted` but the user hasn't been trusted yet), the operation is stored but shown greyed out as pending, awaiting board author approval.
+When a user performs an action they don't have full permission for (e.g. scope
+is `trusted` but the user hasn't been trusted yet), the operation is stored but
+shown greyed out as pending, awaiting board author approval.
 
 ## Sync architecture
 
@@ -244,39 +305,61 @@ Writing (task creation, edits, comments, etc.)
   → Other clients re-fetch from appview, UI updates
 ```
 
-The appview handles all cross-PDS aggregation server-side. On startup with a stale Jetstream cursor (>48h), the appview serves existing cached data immediately while backfilling in the background.
+The appview handles all cross-PDS aggregation server-side. On startup with
+a stale Jetstream cursor (>48h), the appview serves existing cached data
+immediately while backfilling in the background.
 
 ## Appview
 
-The appview (`appview/`) is a caching aggregation server that sits between clients and the AT Protocol network. It runs on Bun with SQLite and deploys to Fly.io.
+The appview (`appview/`) is a caching aggregation server that sits between
+clients and the AT Protocol network. It runs on Bun with SQLite and deploys
+to Fly.io.
 
-- Subscribes to Jetstream for real-time ingestion of all `dev.skyboard.*` records
+- Subscribes to Jetstream for real-time ingestion of all `dev.skyboard.*`
+  records
 - Backfills from PDS endpoints on demand when a board is first requested
-- Serves full board state via `GET /board/:did/:rkey` (one request replaces many PDS fetches)
+- Serves full board state via `GET /board/:did/:rkey` (one request replaces many
+  PDS fetches)
 - Pushes real-time update notifications via WebSocket (`WS /ws?boardUri=...`)
 - Persists Jetstream cursor for graceful restart recovery
 
-See [`appview/README.md`](appview/README.md) for development and deployment details.
+See [`appview/README.md`] for development and deployment details.
+
+[`appview/README.md`]: appview/README.md
 
 ## Tech stack
 
 **Web app:**
-- [SvelteKit](https://kit.svelte.dev/) with Svelte 5 and TypeScript
-- [Dexie](https://dexie.org/) (IndexedDB) for local-first persistence
-- [fractional-indexing](https://www.npmjs.com/package/fractional-indexing) for CRDT-friendly task ordering
-- [@atproto/api](https://www.npmjs.com/package/@atproto/api) and [@atproto/oauth-client-browser](https://www.npmjs.com/package/@atproto/oauth-client-browser) for AT Protocol
-- [CodeMirror](https://codemirror.net/) for markdown card editing
-- Static build via [@sveltejs/adapter-static](https://www.npmjs.com/package/@sveltejs/adapter-static)
+
+- [SvelteKit] with Svelte 5 and TypeScript
+- [Dexie] (IndexedDB) for local-first persistence
+- [fractional-indexing] for CRDT-friendly task ordering
+- [@atproto/api] and [@atproto/oauth-client-browser] for AT Protocol
+- [CodeMirror] for markdown card editing
+- Static build via [@sveltejs/adapter-static]
+
+[@atproto/oauth-client-browser]: https://www.npmjs.com/package/@atproto/oauth-client-browser
+[@sveltejs/adapter-static]: https://www.npmjs.com/package/@sveltejs/adapter-static
+[fractional-indexing]: https://www.npmjs.com/package/fractional-indexing
+[@atproto/api]: https://www.npmjs.com/package/@atproto/api
+[CodeMirror]: https://codemirror.net/
+[SvelteKit]: https://kit.svelte.dev/
+[Dexie]: https://dexie.org/
 
 **Appview:**
-- [Bun](https://bun.sh/) runtime with built-in SQLite and WebSocket support
-- [Hono](https://hono.dev/) for HTTP routing
+- [Bun] runtime with built-in SQLite and WebSocket support
+- [Hono] for HTTP routing
 - SQLite (WAL mode) for data caching
-- Deploys to [Fly.io](https://fly.io/) with persistent volume
+- Deploys to [Fly.io] with persistent volume
+
+[Fly.io]: https://fly.io/
+[Hono]: https://hono.dev/
+[Bun]: https://bun.sh/
 
 ## CLI
 
-Skyboard includes a command-line interface (`sb`) for managing boards and tasks from the terminal. It lives in the `cli/` directory as a standalone package.
+Skyboard includes a command-line interface (`sb`) for managing boards and tasks
+from the terminal. It lives in the `cli/` directory as a standalone package.
 
 ### Install
 
@@ -289,7 +372,9 @@ npm link        # makes `sb` available globally
 
 ### Auth
 
-The CLI uses AT Protocol OAuth with a loopback redirect — `sb login` opens your browser, you authorize with your Bluesky account, and the session is stored locally in `~/.config/skyboard/`.
+The CLI uses AT Protocol OAuth with a loopback redirect — `sb login` opens your
+browser, you authorize with your Bluesky account, and the session is stored
+locally in `~/.config/skyboard/`.
 
 ```bash
 sb login alice.bsky.social    # opens browser for OAuth
@@ -324,7 +409,9 @@ sb comment 3lab "Looks good"  # add comment
 sb rm 3lab                    # delete card (owner only, with confirmation)
 ```
 
-Cards are referenced by **TID rkey prefix** (like git short hashes). `sb cards` shows 7-character truncated rkeys. Columns can be matched by name, prefix (`in` matches `In Progress`), or 1-based index.
+Cards are referenced by **TID rkey prefix** (like git short hashes). `sb cards`
+shows 7-character truncated rkeys. Columns can be matched by name, prefix (`in`
+matches `In Progress`), or 1-based index.
 
 ### JSON output
 
@@ -337,7 +424,12 @@ sb whoami --json
 
 ### How it works
 
-The CLI authenticates via OAuth and fetches board data from the appview — no local database. Each read command hits the appview for the full board state, runs the same `materializeTasks()` merge logic as the web app, and displays the result. Write commands (`new`, `mv`, `edit`, `comment`) create AT Protocol records (tasks, ops, comments) in your PDS, which the appview picks up via Jetstream and serves to other clients.
+The CLI authenticates via OAuth and fetches board data from the appview — no
+local database. Each read command hits the appview for the full board state,
+runs the same `materializeTasks()` merge logic as the web app, and displays
+the result. Write commands (`new`, `mv`, `edit`, `comment`) create AT Protocol
+records (tasks, ops, comments) in your PDS, which the appview picks up via
+Jetstream and serves to other clients.
 
 ## Development
 


### PR DESCRIPTION
I just went through and made everything hard wrap at 80 characters, as well as un-inlining links so things are easier to read when looking at the README without rich text.