### PR TITLE
Replace Shift+H/L shortcuts with {/} to avoid macOS Cmd+H conflict

### DIFF
--- a/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/src/lib/components/KeyboardShortcutsModal.svelte
@@ -40,7 +40,7 @@
       shortcuts: [
         { keys: [","], sep: "/", alt: ["."], description: "Move task left / right" },
         { keys: ["<"], sep: "/", alt: [">"], description: "Move task to top of adjacent column" },
-        { keys: ["\u21E7", "H"], sep: "/", alt: ["\u21E7", "L"], description: "Move task to top of adjacent column" },
+        { keys: ["{"], sep: "/", alt: ["}"], description: "Move task to top of adjacent column" },
         { keys: ["\u21E7", "\u2191"], sep: "/", alt: ["\u21E7", "\u2193"], description: "Reorder task up / down" },
         { keys: ["\u21E7", "K"], sep: "/", alt: ["\u21E7", "J"], description: "Reorder task up / down" },
         { keys: ["m"], description: "Quick move to column" },

--- a/src/routes/board/[did]/[rkey]/+page.svelte
+++ b/src/routes/board/[did]/[rkey]/+page.svelte
@@ -460,12 +460,12 @@
       }
       case "<":
       case ">":
-      case "H":
-      case "L": {
+      case "{":
+      case "}": {
         if (!pos || !auth.did) break;
         const taskTop = sortedTasksByColumn[pos.col]?.[pos.row];
         if (!taskTop) break;
-        const destColTop = e.key === "<" || e.key === "H" ? pos.col - 1 : pos.col + 1;
+        const destColTop = e.key === "<" || e.key === "{" ? pos.col - 1 : pos.col + 1;
         if (destColTop < 0 || destColTop >= numCols) break;
         e.preventDefault();
         const destTasksTop = sortedTasksByColumn[destColTop] ?? [];


### PR DESCRIPTION
## Summary
- Replaced `Shift+H` and `Shift+L` keyboard shortcuts with `{` and `}` for moving tasks to the top of adjacent columns
- This avoids confusion with the macOS system `Cmd+H` (hide window) shortcut
- Updated the KeyboardShortcutsModal to reflect the new bindings
- All other h/j/k/l navigation shortcuts remain unchanged

## Test plan
- [ ] Verify `{` moves the selected task to the top of the left adjacent column
- [ ] Verify `}` moves the selected task to the top of the right adjacent column
- [ ] Verify `h`/`j`/`k`/`l` navigation still works as before
- [ ] Verify `Shift+H` and `Shift+L` no longer trigger any action
- [ ] Verify the keyboard shortcuts modal shows the updated bindings
- [ ] `npm run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)