### PR TITLE
Fix horizontal scrolling on desktop for boards with many columns

### DIFF
--- a/src/lib/components/Column.svelte
+++ b/src/lib/components/Column.svelte
@@ -328,6 +328,7 @@
     min-width: 280px;
     max-width: 340px;
     width: 100%;
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     max-height: calc(100vh - 140px);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -527,7 +527,8 @@
 
   .app-main {
     flex: 1;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   @media (max-width: 600px) {

--- a/src/routes/board/[did]/[rkey]/+page.svelte
+++ b/src/routes/board/[did]/[rkey]/+page.svelte
@@ -1376,6 +1376,7 @@
     display: flex;
     flex-direction: column;
     height: calc(100vh - 56px);
+    overflow: hidden;
   }
 
   .board-header {


### PR DESCRIPTION
## Summary
- Added `flex-shrink: 0` to `.column` in Column.svelte to prevent columns from shrinking below min-width
- Changed `.app-main` overflow from `auto` to `overflow-y: auto; overflow-x: hidden` in +layout.svelte
- Added `overflow: hidden` to `.board-page` in +page.svelte to contain the scroll context to `.columns-container`

## Test plan
- [ ] Open a board with enough columns to exceed viewport width — columns-container should scroll horizontally
- [ ] Verify vertical scrolling within columns still works
- [ ] Verify mobile scrolling behavior is not broken
- [ ] Verify drag auto-scroll still functions during card drag operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)