### PR TITLE
Fix double scrolling in card edit modal with long descriptions

### DIFF
--- a/src/lib/components/TaskEditModal.svelte
+++ b/src/lib/components/TaskEditModal.svelte
@@ -429,10 +429,9 @@
         EditorView.theme({
           "&": {
             fontSize: "0.875rem",
-            maxHeight: "50vh",
           },
           ".cm-scroller": {
-            overflow: "auto",
+            overflow: "visible",
             fontFamily: "inherit",
           },
           ".cm-content": {


### PR DESCRIPTION
## Summary
- Remove `maxHeight: '50vh'` from CodeMirror editor theme so the editor grows to its natural height
- Change `.cm-scroller` overflow from `'auto'` to `'visible'` to eliminate the nested scroll container
- The modal's own `max-height: 90vh; overflow-y: auto` now handles all scrolling as a single unit

## Test plan
- [ ] Open a card with a long description — verify no double/nested scrollbars appear
- [ ] Verify the entire modal scrolls as one unit when content exceeds viewport
- [ ] Open a card with a short description — verify no unnecessary whitespace
- [ ] Test in both edit and read-only modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)