### PR TITLE
Fix keyboard card movement selection stolen by mouse hover

### DIFF
--- a/src/lib/board-nav.svelte.ts
+++ b/src/lib/board-nav.svelte.ts
@@ -16,3 +16,25 @@ export function setSelectedPos(pos: SelectedPos): void {
 export function clearSelection(): void {
   selectedPos = null;
 }
+
+// Hover suppression: prevent onmouseenter from stealing selection after
+// keyboard-based card reordering moves DOM elements under a static cursor.
+let hoverSuppressed = false;
+
+if (typeof window !== "undefined") {
+  window.addEventListener(
+    "mousemove",
+    () => {
+      hoverSuppressed = false;
+    },
+    { passive: true },
+  );
+}
+
+export function suppressHover(): void {
+  hoverSuppressed = true;
+}
+
+export function shouldHandleHover(): boolean {
+  return !hoverSuppressed;
+}

--- a/src/routes/board/[did]/[rkey]/+page.svelte
+++ b/src/routes/board/[did]/[rkey]/+page.svelte
@@ -32,6 +32,8 @@
     getSelectedPos,
     setSelectedPos,
     clearSelection,
+    suppressHover,
+    shouldHandleHover,
   } from "$lib/board-nav.svelte.js";
   import BoardSettingsModal from "$lib/components/BoardSettingsModal.svelte";
   import PermissionsModal from "$lib/components/PermissionsModal.svelte";
@@ -428,6 +430,7 @@
             const newPos = generateKeyBetween(before, after);
             createOp(auth.did, task.sourceTask, boardUri, { position: newPos });
             setSelectedPos({ col: pos.col, row: pos.row - 1 });
+            suppressHover();
           }
         } else {
           setSelectedPos({ col: pos.col, row: Math.max(0, pos.row - 1) });
@@ -449,6 +452,7 @@
             const newPos = generateKeyBetween(before, after);
             createOp(auth.did, task.sourceTask, boardUri, { position: newPos });
             setSelectedPos({ col: pos.col, row: pos.row + 1 });
+            suppressHover();
           }
         } else {
           const maxRow = Math.max(
@@ -1232,8 +1236,11 @@
           onsavetitle={handleSaveTitle}
           onpastelines={handlePasteLines}
           onaddtask={() => addNewCard(colIdx)}
-          onhover={(taskIndex) =>
-            setSelectedPos({ col: colIdx, row: taskIndex })}
+          onhover={(taskIndex) => {
+            if (shouldHandleHover()) {
+              setSelectedPos({ col: colIdx, row: taskIndex });
+            }
+          }}
           ondiscarderrors={handleDiscardErrors}
         />
       {/each}


### PR DESCRIPTION
## Summary
- Fixes a bug where keyboard-based card movement (Cmd+Shift+J/K) had its selection stolen by mouse hover events
- When a card is moved via keyboard, the DOM reorder triggers `onmouseenter` on a different card under the static cursor, overriding the keyboard-set selection

## Changes
- **`src/lib/board-nav.svelte.ts`**: Added mousemove-based hover suppression — `suppressHover()` sets a flag that is cleared only when the mouse genuinely moves, and `shouldHandleHover()` checks the flag
- **`src/routes/board/[did]/[rkey]/+page.svelte`**: Calls `suppressHover()` after keyboard card reorder (Shift+J/K up/down), and guards the `onhover` callback with `shouldHandleHover()`

## Test plan
- [ ] Move a card up with Cmd+Shift+K — selection should stay on the moved card
- [ ] Move a card down with Cmd+Shift+J — selection should stay on the moved card
- [ ] Mouse hover on cards still updates selection when mouse is actually moved
- [ ] Regular keyboard navigation (J/K without Shift) works as before
- [ ] Drag-and-drop card movement is unaffected

Skyboard card: 3mewm6v

🤖 Generated with [Claude Code](https://claude.com/claude-code)