### PR TITLE
Fix CLI card sorting to match web UI

### DIFF
--- a/cli/src/lib/display.ts
+++ b/cli/src/lib/display.ts
@@ -90,10 +90,12 @@ export function printBoardCards(
       );
     }
 
-    // Sort by position
-    colTasks.sort((a, b) =>
-      a.effectivePosition.localeCompare(b.effectivePosition),
-    );
+    // Sort by position, with rkey+did tiebreaker to match UI
+    colTasks.sort((a, b) => {
+      if (a.effectivePosition < b.effectivePosition) return -1;
+      if (a.effectivePosition > b.effectivePosition) return 1;
+      return (a.rkey + a.did).localeCompare(b.rkey + b.did);
+    });
 
     console.log(formatColumnHeader(col, colTasks.length));
     if (colTasks.length === 0) {

--- a/cli/src/lib/pds.ts
+++ b/cli/src/lib/pds.ts
@@ -217,7 +217,9 @@ export async function fetchBoardData(
       createdAt: c.createdAt,
     }));
 
-    const trustedDids = new Set(trusts.map((t) => t.trustedDid));
+    const trustedDids = new Set(
+      trusts.filter((t) => t.did === boardDid).map((t) => t.trustedDid),
+    );
 
     const allParticipants = new Set<string>();
     allParticipants.add(boardDid);


### PR DESCRIPTION
## Summary

- Fix trust set filtering in CLI to only use board owner's trust records (matching appview and web UI behavior)
- Add rkey+did tiebreaker to CLI card sort to match the web UI's Column.svelte sort

## Details

Two bugs caused CLI `sb cards` to show cards in a different order than the web UI:

1. **Trust set not filtered by board owner DID** (`cli/src/lib/pds.ts`): The CLI was building the trusted DIDs set from ALL trust records instead of only the board owner's. This caused extra ops to be applied, producing different `effectivePosition` values.

2. **Missing sort tiebreaker** (`cli/src/lib/display.ts`): The CLI sorted only by `effectivePosition` without a tiebreaker, while the UI uses `rkey + did` to break ties deterministically.

## Test plan

- [x] All 66 CLI tests pass
- [x] svelte-check passes with 0 errors
- [ ] Verify CLI card ordering matches web UI on a board with multiple participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)