### PR TITLE
Add syntax highlighting for code blocks in editor and rendered markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "dexie": "^4.0.11",
         "dompurify": "^3.3.1",
         "fractional-indexing": "^3.2.0",
+        "highlight.js": "^11.11.1",
         "marked": "^17.0.1",
+        "marked-highlight": "^2.2.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2246,6 +2248,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2314,6 +2325,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.3.tgz",
+      "integrity": "sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <18"
       }
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "dexie": "^4.0.11",
     "dompurify": "^3.3.1",
     "fractional-indexing": "^3.2.0",
+    "highlight.js": "^11.11.1",
     "marked": "^17.0.1",
+    "marked-highlight": "^2.2.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/lib/components/TaskEditModal.svelte
+++ b/src/lib/components/TaskEditModal.svelte
@@ -22,9 +22,42 @@
   import { markdownLivePreview } from "$lib/markdown-live-preview.js";
   import { formattingToolbar } from "$lib/editor-formatting-toolbar.js";
   import { Marked } from "marked";
+  import { markedHighlight } from "marked-highlight";
+  import hljs from "highlight.js/lib/core";
+  import javascript from "highlight.js/lib/languages/javascript";
+  import typescript from "highlight.js/lib/languages/typescript";
+  import python from "highlight.js/lib/languages/python";
+  import rust from "highlight.js/lib/languages/rust";
+  import go from "highlight.js/lib/languages/go";
+  import css from "highlight.js/lib/languages/css";
+  import xml from "highlight.js/lib/languages/xml";
+  import json from "highlight.js/lib/languages/json";
+  import yaml from "highlight.js/lib/languages/yaml";
+  import bash from "highlight.js/lib/languages/bash";
+  import sql from "highlight.js/lib/languages/sql";
+  import markdown_hl from "highlight.js/lib/languages/markdown";
   import { mentionExtension } from "$lib/mention-markdown.js";
   import BlockInsertMenu from "./BlockInsertMenu.svelte";
   import DOMPurify from "dompurify";
+
+  hljs.registerLanguage("javascript", javascript);
+  hljs.registerLanguage("js", javascript);
+  hljs.registerLanguage("typescript", typescript);
+  hljs.registerLanguage("ts", typescript);
+  hljs.registerLanguage("python", python);
+  hljs.registerLanguage("rust", rust);
+  hljs.registerLanguage("go", go);
+  hljs.registerLanguage("css", css);
+  hljs.registerLanguage("html", xml);
+  hljs.registerLanguage("xml", xml);
+  hljs.registerLanguage("json", json);
+  hljs.registerLanguage("yaml", yaml);
+  hljs.registerLanguage("bash", bash);
+  hljs.registerLanguage("shell", bash);
+  hljs.registerLanguage("sh", bash);
+  hljs.registerLanguage("sql", sql);
+  hljs.registerLanguage("markdown", markdown_hl);
+  hljs.registerLanguage("md", markdown_hl);
 
   DOMPurify.addHook("afterSanitizeAttributes", (node) => {
     if (node.tagName === "A") {
@@ -33,13 +66,24 @@
     }
   });
 
-  const markedInstance = new Marked(mentionExtension(), {
-    renderer: {
-      checkbox({ checked }: { checked: boolean }) {
-        return `<input ${checked ? 'checked="" ' : ""}type="checkbox"> `;
+  const markedInstance = new Marked(
+    markedHighlight({
+      highlight(code, lang) {
+        if (lang && hljs.getLanguage(lang)) {
+          return hljs.highlight(code, { language: lang }).value;
+        }
+        return code;
+      },
+    }),
+    mentionExtension(),
+    {
+      renderer: {
+        checkbox({ checked }: { checked: boolean }) {
+          return `<input ${checked ? 'checked="" ' : ""}type="checkbox"> `;
+        },
       },
     },
-  });
+  );
 
   const EMOJI_OPTIONS = [
     "\u{1F44D}",
@@ -1394,6 +1438,69 @@
   .rendered-description :global(pre code) {
     background: none;
     padding: 0;
+  }
+
+  /* highlight.js syntax highlighting tokens */
+  .rendered-description :global(.hljs-keyword),
+  .rendered-description :global(.hljs-selector-tag),
+  .rendered-description :global(.hljs-built_in) {
+    color: #8b5cf6;
+  }
+
+  .rendered-description :global(.hljs-string),
+  .rendered-description :global(.hljs-attr) {
+    color: #16a34a;
+  }
+
+  .rendered-description :global(.hljs-comment),
+  .rendered-description :global(.hljs-doctag) {
+    color: #6b7280;
+    font-style: italic;
+  }
+
+  .rendered-description :global(.hljs-number),
+  .rendered-description :global(.hljs-literal) {
+    color: #d97706;
+  }
+
+  .rendered-description :global(.hljs-title),
+  .rendered-description :global(.hljs-title.function_) {
+    color: #2563eb;
+  }
+
+  .rendered-description :global(.hljs-type),
+  .rendered-description :global(.hljs-title.class_) {
+    color: #0d9488;
+  }
+
+  .rendered-description :global(.hljs-variable),
+  .rendered-description :global(.hljs-template-variable) {
+    color: #dc2626;
+  }
+
+  .rendered-description :global(.hljs-tag) {
+    color: #dc2626;
+  }
+
+  .rendered-description :global(.hljs-name) {
+    color: #dc2626;
+  }
+
+  .rendered-description :global(.hljs-attribute) {
+    color: #d97706;
+  }
+
+  .rendered-description :global(.hljs-regexp) {
+    color: #d97706;
+  }
+
+  .rendered-description :global(.hljs-symbol),
+  .rendered-description :global(.hljs-meta) {
+    color: #8b5cf6;
+  }
+
+  .rendered-description :global(.hljs-params) {
+    color: inherit;
   }
 
   .rendered-description :global(blockquote) {

--- a/src/lib/markdown-live-preview.ts
+++ b/src/lib/markdown-live-preview.ts
@@ -176,6 +176,13 @@ function buildDecorations(view: EditorView): DecorationSet {
             return false;
           }
 
+          case "FencedCode": {
+            decs.push(
+              Decoration.mark({ class: "cm-md-fenced-code" }).range(from, to),
+            );
+            break;
+          }
+
           case "Link": {
             const linkMarks = nodeRef.node.getChildren("LinkMark");
             const urls = nodeRef.node.getChildren("URL");
@@ -246,6 +253,10 @@ const theme = EditorView.baseTheme({
     color: "var(--color-primary, #3b82f6)",
     textDecoration: "underline",
   },
+  ".cm-md-fenced-code": {
+    backgroundColor: "rgba(128, 128, 128, 0.08)",
+    borderRadius: "4px",
+  },
   ".cm-task-checkbox": {
     cursor: "pointer",
     margin: "0 2px 0 0",
@@ -255,12 +266,30 @@ const theme = EditorView.baseTheme({
   },
 });
 
-const linkHighlight = HighlightStyle.define([
+const codeHighlight = HighlightStyle.define([
   { tag: [tags.link, tags.url], color: "var(--color-primary, #3b82f6)" },
+  { tag: tags.keyword, color: "#8b5cf6" },
+  { tag: tags.string, color: "#16a34a" },
+  { tag: tags.comment, color: "#6b7280", fontStyle: "italic" },
+  { tag: tags.number, color: "#d97706" },
+  { tag: tags.bool, color: "#d97706" },
+  { tag: tags.null, color: "#d97706" },
+  { tag: tags.function(tags.variableName), color: "#2563eb" },
+  { tag: tags.typeName, color: "#0d9488" },
+  { tag: tags.className, color: "#0d9488" },
+  { tag: tags.operator, color: "#dc2626" },
+  { tag: tags.propertyName, color: "#2563eb" },
+  { tag: tags.definition(tags.variableName), color: "#2563eb" },
+  { tag: tags.angleBracket, color: "#6b7280" },
+  { tag: tags.tagName, color: "#dc2626" },
+  { tag: tags.attributeName, color: "#d97706" },
+  { tag: tags.attributeValue, color: "#16a34a" },
+  { tag: tags.regexp, color: "#d97706" },
+  { tag: tags.self, color: "#8b5cf6" },
 ]);
 
 export const markdownLivePreview = [
   plugin,
   theme,
-  syntaxHighlighting(linkHighlight),
+  syntaxHighlighting(codeHighlight),
 ];

--- a/src/lib/markdown-live-preview.ts
+++ b/src/lib/markdown-live-preview.ts
@@ -256,6 +256,8 @@ const theme = EditorView.baseTheme({
   ".cm-md-fenced-code": {
     backgroundColor: "rgba(128, 128, 128, 0.08)",
     borderRadius: "4px",
+    fontFamily: "monospace",
+    fontSize: "0.9em",
   },
   ".cm-task-checkbox": {
     cursor: "pointer",

--- a/src/lib/markdown-live-preview.ts
+++ b/src/lib/markdown-live-preview.ts
@@ -177,9 +177,55 @@ function buildDecorations(view: EditorView): DecorationSet {
           }
 
           case "FencedCode": {
-            decs.push(
-              Decoration.mark({ class: "cm-md-fenced-code" }).range(from, to),
-            );
+            const codeMarks = nodeRef.node.getChildren("CodeMark");
+
+            // Hide opening fence line including its trailing newline
+            if (codeMarks.length > 0) {
+              const openMark = codeMarks[0];
+              const openLine = view.state.doc.lineAt(openMark.from);
+              // Include the newline after the fence line to collapse it
+              const hideEnd = Math.min(openLine.to + 1, to);
+              decs.push(Decoration.replace({}).range(openLine.from, hideEnd));
+            }
+
+            // Hide closing fence line including its leading newline
+            if (codeMarks.length > 1) {
+              const closeMark = codeMarks[codeMarks.length - 1];
+              const closeLine = view.state.doc.lineAt(closeMark.from);
+              // Include the newline before the fence line to collapse it
+              const hideStart = Math.max(closeLine.from - 1, from);
+              decs.push(Decoration.replace({}).range(hideStart, closeLine.to));
+            }
+
+            // Apply line decoration with full-width background to each code line
+            const codeTexts = nodeRef.node.getChildren("CodeText");
+            for (const ct of codeTexts) {
+              // CodeText may span multiple lines — iterate each line
+              let pos = ct.from;
+              while (pos <= ct.to) {
+                const line = view.state.doc.lineAt(pos);
+                decs.push(
+                  Decoration.line({ class: "cm-md-fenced-code-line" }).range(
+                    line.from,
+                  ),
+                );
+                // Move to next line
+                if (line.to >= ct.to) break;
+                pos = line.to + 1;
+              }
+            }
+
+            // Also apply mark decoration for monospace font on the code text
+            for (const ct of codeTexts) {
+              if (ct.from < ct.to) {
+                decs.push(
+                  Decoration.mark({ class: "cm-md-fenced-code" }).range(
+                    ct.from,
+                    ct.to,
+                  ),
+                );
+              }
+            }
             break;
           }
 
@@ -254,10 +300,11 @@ const theme = EditorView.baseTheme({
     textDecoration: "underline",
   },
   ".cm-md-fenced-code": {
-    backgroundColor: "rgba(128, 128, 128, 0.08)",
-    borderRadius: "4px",
     fontFamily: "monospace",
     fontSize: "0.9em",
+  },
+  ".cm-md-fenced-code-line": {
+    backgroundColor: "rgba(128, 128, 128, 0.08)",
   },
   ".cm-task-checkbox": {
     cursor: "pointer",


### PR DESCRIPTION
## Summary
- Add syntax highlighting for fenced code blocks (```js, ```python, etc.) in both the CodeMirror editor and the rendered markdown view for card descriptions and comments
- Editor uses lezer-based token highlighting via HighlightStyle with 19 tag-to-color mappings (keywords, strings, comments, numbers, types, functions, operators, etc.)
- Rendered view uses highlight.js + marked-highlight with 12 individually-imported languages (JS, TS, Python, Rust, Go, CSS, HTML, JSON, YAML, Bash, SQL, Markdown)
- Fenced code blocks in the editor get a subtle background decoration to distinguish them from prose

## Test plan
- [ ] Verify fenced code blocks with language identifiers show syntax highlighting in the CodeMirror editor
- [ ] Verify fenced code blocks in rendered (read-only) descriptions and comments show syntax highlighting
- [ ] Verify highlighting works in both light and dark modes
- [ ] Verify languages without parsers fall back gracefully to plain monospace text
- [ ] Verify no regression in existing inline markdown live-preview (bold, italic, links, headings)
- [ ] Verify bundle size impact is reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)