### PR TITLE
Add card linking feature (dev.skyboard.link)

### DIFF
--- a/appview/src/api/get-board.ts
+++ b/appview/src/api/get-board.ts
@@ -8,6 +8,7 @@ import {
   getCommentsByBoard,
   getApprovalsByBoard,
   getReactionsByBoard,
+  getLinksByBoard,
   type TaskRow,
   type OpRow,
   type BoardRow,
@@ -224,6 +225,15 @@ export interface BoardResponse {
     trustedDid: string;
     createdAt: string;
   }>;
+  links: Array<{
+    uri: string;
+    did: string;
+    rkey: string;
+    sourceTaskUri: string;
+    targetTaskUri: string;
+    linkType: string;
+    createdAt: string;
+  }>;
 }
 
 export function getBoardData(did: string, rkey: string): BoardResponse | null {
@@ -237,6 +247,7 @@ export function getBoardData(did: string, rkey: string): BoardResponse | null {
   const commentRows = getCommentsByBoard(boardUri);
   const approvalRows = getApprovalsByBoard(boardUri);
   const reactionRows = getReactionsByBoard(boardUri);
+  const linkRows = getLinksByBoard(boardUri);
 
   const trustedDids = new Set(
     trustRows.filter((t) => t.did === did).map((t) => t.trustedDid),
@@ -309,6 +320,15 @@ export function getBoardData(did: string, rkey: string): BoardResponse | null {
       rkey: t.rkey,
       trustedDid: t.trustedDid,
       createdAt: t.createdAt,
+    })),
+    links: linkRows.map((l) => ({
+      uri: l.uri,
+      did: l.did,
+      rkey: l.rkey,
+      sourceTaskUri: l.sourceTaskUri,
+      targetTaskUri: l.targetTaskUri,
+      linkType: l.linkType,
+      createdAt: l.createdAt,
     })),
   };
 }

--- a/appview/src/db/schema.sql
+++ b/appview/src/db/schema.sql
@@ -88,6 +88,19 @@ CREATE TABLE IF NOT EXISTS reactions (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_reactions_did_rkey ON reactions(did, rkey);
 CREATE INDEX IF NOT EXISTS idx_reactions_boardUri ON reactions(boardUri);
 
+CREATE TABLE IF NOT EXISTS links (
+  uri TEXT PRIMARY KEY,
+  did TEXT NOT NULL,
+  rkey TEXT NOT NULL,
+  sourceTaskUri TEXT NOT NULL,
+  targetTaskUri TEXT NOT NULL,
+  boardUri TEXT NOT NULL,
+  linkType TEXT NOT NULL,
+  createdAt TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_links_did_rkey ON links(did, rkey);
+CREATE INDEX IF NOT EXISTS idx_links_boardUri ON links(boardUri);
+
 CREATE TABLE IF NOT EXISTS board_participants (
   did TEXT NOT NULL,
   boardUri TEXT NOT NULL,

--- a/appview/src/shared/collections.ts
+++ b/appview/src/shared/collections.ts
@@ -5,6 +5,7 @@ export const TRUST_COLLECTION = "dev.skyboard.trust";
 export const COMMENT_COLLECTION = "dev.skyboard.comment";
 export const APPROVAL_COLLECTION = "dev.skyboard.approval";
 export const REACTION_COLLECTION = "dev.skyboard.reaction";
+export const LINK_COLLECTION = "dev.skyboard.link";
 
 export const ALL_COLLECTIONS = [
   BOARD_COLLECTION,
@@ -14,6 +15,7 @@ export const ALL_COLLECTIONS = [
   COMMENT_COLLECTION,
   APPROVAL_COLLECTION,
   REACTION_COLLECTION,
+  LINK_COLLECTION,
 ];
 
 export function buildAtUri(

--- a/appview/src/shared/schemas.ts
+++ b/appview/src/shared/schemas.ts
@@ -83,6 +83,14 @@ export const ReactionRecordSchema = z.object({
   createdAt: z.string().max(MAX_STRING),
 });
 
+export const LinkRecordSchema = z.object({
+  sourceTaskUri: z.string().max(MAX_STRING),
+  targetTaskUri: z.string().max(MAX_STRING),
+  boardUri: z.string().max(MAX_STRING),
+  linkType: z.string().max(MAX_STRING),
+  createdAt: z.string().max(MAX_STRING),
+});
+
 export function safeParse<T>(
   schema: z.ZodType<T>,
   data: unknown,

--- a/src/lib/appview.ts
+++ b/src/lib/appview.ts
@@ -7,6 +7,7 @@ import type {
   Comment,
   Approval,
   Reaction,
+  Link,
 } from "./types.js";
 const APPVIEW_URL =
   typeof window !== "undefined" &&
@@ -77,6 +78,7 @@ export async function loadBoardFromAppview(
         db.comments,
         db.approvals,
         db.reactions,
+        db.links,
       ],
       async () => {
         // Store board
@@ -304,6 +306,40 @@ export async function loadBoardFromAppview(
             }
           } else {
             await db.reactions.add(reactionData as Reaction);
+          }
+        }
+
+        // Store links
+        for (const l of data.links ?? []) {
+          const linkData: Omit<Link, "id"> = {
+            rkey: l.rkey,
+            did: l.did,
+            sourceTaskUri: l.sourceTaskUri,
+            targetTaskUri: l.targetTaskUri,
+            boardUri,
+            linkType: l.linkType,
+            createdAt: l.createdAt,
+            syncStatus: "synced",
+          };
+
+          const existing = await db.links
+            .where("[did+rkey]")
+            .equals([l.did, l.rkey])
+            .first();
+          if (existing?.id) {
+            if (existing.syncStatus === "pending") continue;
+            if (
+              !recordsEqual(existing, linkData, [
+                "sourceTaskUri",
+                "targetTaskUri",
+                "linkType",
+                "createdAt",
+              ])
+            ) {
+              await db.links.update(existing.id, linkData);
+            }
+          } else {
+            await db.links.add(linkData as Link);
           }
         }
       },

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -6,7 +6,7 @@ import {
 import { openDb, closeDb } from "./db.js";
 
 const OAUTH_SCOPE =
-  "atproto repo:dev.skyboard.board repo:dev.skyboard.task repo:dev.skyboard.op repo:dev.skyboard.trust repo:dev.skyboard.comment repo:dev.skyboard.approval repo:dev.skyboard.reaction";
+  "atproto repo:dev.skyboard.board repo:dev.skyboard.task repo:dev.skyboard.op repo:dev.skyboard.trust repo:dev.skyboard.comment repo:dev.skyboard.approval repo:dev.skyboard.reaction repo:dev.skyboard.link";
 
 let agent = $state<Agent | null>(null);
 let did = $state<string | null>(null);

--- a/src/lib/components/Column.svelte
+++ b/src/lib/components/Column.svelte
@@ -23,6 +23,7 @@
     ownerTrustedDids,
     approvedUris,
     commentCounts = new Map(),
+    linkCounts = new Map(),
     reactionsByTask = new Map(),
     boardLabels = [],
     onedit,
@@ -45,6 +46,7 @@
     ownerTrustedDids: Set<string>;
     approvedUris: Set<string>;
     commentCounts?: Map<string, number>;
+    linkCounts?: Map<string, number>;
     reactionsByTask?: Map<
       string,
       Map<string, { count: number; userReacted: boolean }>
@@ -282,6 +284,9 @@
           currentUserDid={did}
           pending={isTaskPending(task)}
           commentCount={commentCounts.get(
+            `at://${task.ownerDid}/dev.skyboard.task/${task.rkey}`,
+          ) ?? 0}
+          linkCount={linkCounts.get(
             `at://${task.ownerDid}/dev.skyboard.task/${task.rkey}`,
           ) ?? 0}
           reactions={reactionsByTask.get(

--- a/src/lib/components/TaskCard.svelte
+++ b/src/lib/components/TaskCard.svelte
@@ -35,6 +35,7 @@
     currentUserDid,
     pending = false,
     commentCount = 0,
+    linkCount = 0,
     reactions,
     onreact,
     taskUri = "",
@@ -51,6 +52,7 @@
     currentUserDid: string;
     pending?: boolean;
     commentCount?: number;
+    linkCount?: number;
     reactions?: Map<string, { count: number; userReacted: boolean }>;
     onreact?: (taskUri: string, emoji: string) => void;
     taskUri?: string;
@@ -450,6 +452,25 @@
         {commentCount}
       </span>
     {/if}
+    {#if linkCount > 0}
+      <span
+        class="link-badge"
+        title="{linkCount} link{linkCount === 1 ? '' : 's'}"
+      >
+        <svg
+          class="link-icon"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <path d="M6.5 9.5l3-3" />
+          <path d="M9 10.5l1.5 1.5a2.12 2.12 0 003-3L12 7.5" />
+          <path d="M7 5.5L5.5 4a2.12 2.12 0 00-3 3L4 8.5" />
+        </svg>
+        {linkCount}
+      </span>
+    {/if}
     {#if todoStats}
       <span
         class="todo-badge"
@@ -752,6 +773,23 @@
     padding: 0 0.3125rem;
     border-radius: var(--radius-sm);
     font-weight: 600;
+  }
+
+  .link-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
+    font-size: 0.75rem;
+    background: var(--color-border);
+    color: var(--color-text-secondary);
+    padding: 0 0.3125rem;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+  }
+
+  .link-icon {
+    width: 0.75rem;
+    height: 0.75rem;
   }
 
   .pending-badge {

--- a/src/lib/components/TaskEditModal.svelte
+++ b/src/lib/components/TaskEditModal.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
   import { untrack } from "svelte";
   import { db } from "$lib/db.js";
-  import type { MaterializedTask, Comment, Label, Column } from "$lib/types.js";
+  import type {
+    MaterializedTask,
+    Comment,
+    Link,
+    Label,
+    Column,
+  } from "$lib/types.js";
   import { createOp } from "$lib/ops.js";
   import { createComment, deleteComment } from "$lib/comments.js";
+  import { createLink, deleteLink } from "$lib/links.js";
+  import { TASK_COLLECTION } from "$lib/tid.js";
   import { getAuth } from "$lib/auth.svelte.js";
   import { deleteTaskFromPDS } from "$lib/sync.js";
   import { getActionStatus, isContentVisible } from "$lib/permissions.js";
@@ -58,6 +66,8 @@
     approvedUris,
     comments = [],
     reactions,
+    links = [],
+    allTasks = [],
     boardLabels = [],
     boardUri = "",
     columns = [],
@@ -74,6 +84,8 @@
     approvedUris: Set<string>;
     comments?: Comment[];
     reactions?: Map<string, { count: number; userReacted: boolean }>;
+    links?: Link[];
+    allTasks?: MaterializedTask[];
     boardLabels?: Label[];
     boardUri?: string;
     columns?: Column[];
@@ -392,6 +404,79 @@
       .map((id) => boardLabels.find((l) => l.id === id))
       .filter((l): l is Label => l !== undefined),
   );
+
+  // --- Links ---
+
+  const LINK_TYPE_LABELS: Record<string, string> = {
+    blocks: "blocks",
+    relates_to: "relates to",
+    duplicates: "duplicates",
+  };
+  const INVERSE_LINK_LABELS: Record<string, string> = {
+    blocks: "blocked by",
+    relates_to: "relates to",
+    duplicates: "duplicated by",
+  };
+
+  let showAddLink = $state(false);
+  let newLinkType = $state("relates_to");
+  let newLinkTargetRkey = $state("");
+
+  // Tasks available for linking (exclude current task)
+  const linkableTaskOptions = $derived(
+    allTasks
+      .filter((t) => !(t.rkey === task.rkey && t.ownerDid === task.ownerDid))
+      .map((t) => ({
+        uri: buildAtUri(t.ownerDid, TASK_COLLECTION, t.rkey),
+        rkey: t.rkey,
+        did: t.ownerDid,
+        title: t.effectiveTitle,
+      })),
+  );
+
+  function getLinkLabel(link: Link): string {
+    if (link.sourceTaskUri === taskUri) {
+      return LINK_TYPE_LABELS[link.linkType] ?? link.linkType;
+    }
+    return INVERSE_LINK_LABELS[link.linkType] ?? link.linkType;
+  }
+
+  function getLinkedTaskUri(link: Link): string {
+    return link.sourceTaskUri === taskUri
+      ? link.targetTaskUri
+      : link.sourceTaskUri;
+  }
+
+  function getLinkedTaskTitle(link: Link): string {
+    const linkedUri = getLinkedTaskUri(link);
+    const found = allTasks.find(
+      (t) => buildAtUri(t.ownerDid, TASK_COLLECTION, t.rkey) === linkedUri,
+    );
+    return found?.effectiveTitle ?? "Unknown task";
+  }
+
+  async function handleAddLink() {
+    if (!currentUserDid || !newLinkTargetRkey) return;
+    const target = linkableTaskOptions.find(
+      (t) => t.rkey === newLinkTargetRkey,
+    );
+    if (!target) return;
+
+    await createLink(
+      currentUserDid,
+      taskUri,
+      target.uri,
+      boardUri,
+      newLinkType,
+    );
+    newLinkTargetRkey = "";
+    newLinkType = "relates_to";
+    showAddLink = false;
+  }
+
+  async function handleDeleteLink(link: Link) {
+    await deleteLink(link);
+  }
 
   let editorContainer: HTMLDivElement | undefined = $state();
   let editorView: EditorView | undefined = $state();
@@ -802,6 +887,62 @@
                   newLabelName = "";
                 }}>&times;</button
               >
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      {#if links.length > 0 || !readonly}
+        <div class="links-section">
+          <div class="links-header">
+            <label>Links ({links.length})</label>
+            {#if !readonly}
+              <button
+                class="add-link-btn"
+                onclick={() => (showAddLink = !showAddLink)}
+              >
+                {showAddLink ? "Cancel" : "+ Add link"}
+              </button>
+            {/if}
+          </div>
+
+          {#if showAddLink}
+            <div class="add-link-form">
+              <select bind:value={newLinkType} class="link-type-select">
+                <option value="relates_to">relates to</option>
+                <option value="blocks">blocks</option>
+                <option value="duplicates">duplicates</option>
+              </select>
+              <select bind:value={newLinkTargetRkey} class="link-target-select">
+                <option value="">Select a task...</option>
+                {#each linkableTaskOptions as opt}
+                  <option value={opt.rkey}>{opt.title}</option>
+                {/each}
+              </select>
+              <button
+                class="add-link-confirm"
+                onclick={handleAddLink}
+                disabled={!newLinkTargetRkey}>Add</button
+              >
+            </div>
+          {/if}
+
+          {#if links.length > 0}
+            <div class="links-list">
+              {#each links as link}
+                <div class="link-item">
+                  <span class="link-type-label">{getLinkLabel(link)}</span>
+                  <span class="link-task-title">{getLinkedTaskTitle(link)}</span
+                  >
+                  {#if !readonly && (link.did === currentUserDid || currentUserDid === boardOwnerDid)}
+                    <button
+                      class="link-delete-btn"
+                      onclick={() => handleDeleteLink(link)}
+                      title="Remove link">&times;</button
+                    >
+                  {/if}
+                </div>
+              {/each}
             </div>
           {/if}
         </div>
@@ -1585,6 +1726,123 @@
     height: 0.5rem;
     border-radius: 50%;
     flex-shrink: 0;
+  }
+
+  .links-section {
+    margin-top: 0.75rem;
+    border-top: 1px solid var(--color-border-light);
+    padding: 0.75rem 1.25rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .links-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .links-header label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+  }
+
+  .add-link-btn {
+    background: none;
+    border: none;
+    font-size: 0.75rem;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .add-link-btn:hover {
+    text-decoration: underline;
+  }
+
+  .add-link-form {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .link-type-select,
+  .link-target-select {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: 0.8125rem;
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .link-target-select {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .add-link-confirm {
+    padding: 0.3rem 0.625rem;
+    background: var(--color-primary);
+    color: white;
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+
+  .add-link-confirm:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .links-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .link-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.5rem;
+    background: var(--color-bg);
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+  }
+
+  .link-type-label {
+    color: var(--color-text-secondary);
+    font-weight: 500;
+    font-size: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .link-task-title {
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .link-delete-btn {
+    margin-left: auto;
+    background: none;
+    border: none;
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    padding: 0 0.25rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  .link-delete-btn:hover {
+    color: var(--color-error);
   }
 
   .comments-section {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,6 +7,7 @@ import type {
   Comment,
   Approval,
   Reaction,
+  Link,
   Block,
   Notification,
   FilterView,
@@ -20,6 +21,7 @@ type SkyboardDb = Dexie & {
   comments: EntityTable<Comment, "id">;
   approvals: EntityTable<Approval, "id">;
   reactions: EntityTable<Reaction, "id">;
+  links: EntityTable<Link, "id">;
   blocks: EntityTable<Block, "id">;
   notifications: EntityTable<Notification, "id">;
   filterViews: EntityTable<FilterView, "id">;
@@ -166,6 +168,11 @@ function createDb(name: string): SkyboardDb {
   // Drop the knownParticipants table (no longer needed with the appview)
   d.version(10).stores({
     knownParticipants: null,
+  });
+
+  d.version(11).stores({
+    links:
+      "++id, rkey, did, sourceTaskUri, targetTaskUri, boardUri, syncStatus, [did+rkey]",
   });
 
   return d;

--- a/src/lib/lexicons/link.json
+++ b/src/lib/lexicons/link.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "dev.skyboard.link",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A directional link between two tasks on the same board",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "sourceTaskUri",
+          "targetTaskUri",
+          "boardUri",
+          "linkType",
+          "createdAt"
+        ],
+        "properties": {
+          "sourceTaskUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the source task"
+          },
+          "targetTaskUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the target task"
+          },
+          "boardUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT URI of the board this link belongs to"
+          },
+          "linkType": {
+            "type": "string",
+            "knownValues": ["blocks", "relates_to", "duplicates"],
+            "description": "The type of relationship between the tasks"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the link was created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,55 @@
+import { db } from "./db.js";
+import { generateTID, LINK_COLLECTION } from "./tid.js";
+import { getAuth } from "./auth.svelte.js";
+import type { Link, LinkRecord } from "./types.js";
+
+export async function createLink(
+  authorDid: string,
+  sourceTaskUri: string,
+  targetTaskUri: string,
+  boardUri: string,
+  linkType: string,
+): Promise<void> {
+  await db.links.add({
+    rkey: generateTID(),
+    did: authorDid,
+    sourceTaskUri,
+    targetTaskUri,
+    boardUri,
+    linkType,
+    createdAt: new Date().toISOString(),
+    syncStatus: "pending",
+  });
+}
+
+export async function deleteLink(link: Link): Promise<void> {
+  if (!link.id) return;
+
+  if (link.syncStatus === "synced") {
+    const auth = getAuth();
+    if (auth.agent) {
+      try {
+        await auth.agent.com.atproto.repo.deleteRecord({
+          repo: link.did,
+          collection: LINK_COLLECTION,
+          rkey: link.rkey,
+        });
+      } catch (err) {
+        console.error("Failed to delete link from PDS:", err);
+      }
+    }
+  }
+
+  await db.links.delete(link.id);
+}
+
+export function linkToRecord(link: Link): LinkRecord {
+  return {
+    $type: "dev.skyboard.link",
+    sourceTaskUri: link.sourceTaskUri,
+    targetTaskUri: link.targetTaskUri,
+    boardUri: link.boardUri,
+    linkType: link.linkType,
+    createdAt: link.createdAt,
+  };
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -8,6 +8,7 @@ import {
   COMMENT_COLLECTION,
   APPROVAL_COLLECTION,
   REACTION_COLLECTION,
+  LINK_COLLECTION,
   buildAtUri,
 } from "./tid.js";
 import type {
@@ -18,6 +19,7 @@ import type {
   Comment,
   Approval,
   Reaction,
+  Link,
   BoardRecord,
   TaskRecord,
 } from "./types.js";
@@ -26,6 +28,7 @@ import { trustToRecord } from "./trust.js";
 import { commentToRecord } from "./comments.js";
 import { approvalToRecord } from "./approvals.js";
 import { reactionToRecord } from "./reactions.js";
+import { linkToRecord } from "./links.js";
 
 let syncInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -259,6 +262,33 @@ export async function syncPendingToPDS(
       }
     }
   }
+
+  // Sync pending links
+  const pendingLinks = await db.links
+    .where("syncStatus")
+    .equals("pending")
+    .filter((l) => l.did === did)
+    .toArray();
+
+  for (const link of pendingLinks) {
+    try {
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: LINK_COLLECTION,
+        rkey: link.rkey,
+        record: linkToRecord(link),
+        validate: false,
+      });
+      if (link.id) {
+        await db.links.update(link.id, { syncStatus: "synced" });
+      }
+    } catch (err) {
+      console.error("Failed to sync link to PDS:", err);
+      if (link.id && !isNetworkError(err)) {
+        await db.links.update(link.id, { syncStatus: "error" });
+      }
+    }
+  }
 }
 
 export async function deleteBoardFromPDS(
@@ -343,6 +373,27 @@ export async function deleteBoardFromPDS(
         });
       } catch (err) {
         console.error("Failed to delete reaction from PDS:", err);
+      }
+    }
+  }
+
+  // Delete links from PDS
+  const links = await db.links
+    .where("boardUri")
+    .equals(boardUri)
+    .filter((l) => l.did === did)
+    .toArray();
+
+  for (const link of links) {
+    if (link.syncStatus === "synced") {
+      try {
+        await agent.com.atproto.repo.deleteRecord({
+          repo: did,
+          collection: LINK_COLLECTION,
+          rkey: link.rkey,
+        });
+      } catch (err) {
+        console.error("Failed to delete link from PDS:", err);
       }
     }
   }
@@ -451,6 +502,24 @@ export async function deleteReactionFromPDS(
   }
 }
 
+export async function deleteLinkFromPDS(
+  agent: Agent,
+  did: string,
+  link: Link,
+): Promise<void> {
+  if (link.syncStatus === "synced") {
+    try {
+      await agent.com.atproto.repo.deleteRecord({
+        repo: did,
+        collection: LINK_COLLECTION,
+        rkey: link.rkey,
+      });
+    } catch (err) {
+      console.error("Failed to delete link from PDS:", err);
+    }
+  }
+}
+
 async function resetErrorsToPending(did: string): Promise<void> {
   const tables = [
     db.boards,
@@ -460,6 +529,7 @@ async function resetErrorsToPending(did: string): Promise<void> {
     db.comments,
     db.approvals,
     db.reactions,
+    db.links,
   ];
   for (const table of tables) {
     const errored = await (table as any)

--- a/src/lib/tid.ts
+++ b/src/lib/tid.ts
@@ -7,6 +7,7 @@ export const TRUST_COLLECTION = "dev.skyboard.trust";
 export const COMMENT_COLLECTION = "dev.skyboard.comment";
 export const APPROVAL_COLLECTION = "dev.skyboard.approval";
 export const REACTION_COLLECTION = "dev.skyboard.reaction";
+export const LINK_COLLECTION = "dev.skyboard.link";
 
 export function generateTID(): string {
   return TID.nextStr();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -156,6 +156,29 @@ export interface ReactionRecord {
   createdAt: string;
 }
 
+// --- Link types ---
+
+export interface Link {
+  id?: number;
+  rkey: string;
+  did: string;
+  sourceTaskUri: string;
+  targetTaskUri: string;
+  boardUri: string;
+  linkType: string;
+  createdAt: string;
+  syncStatus: SyncStatus;
+}
+
+export interface LinkRecord {
+  $type: "dev.skyboard.link";
+  sourceTaskUri: string;
+  targetTaskUri: string;
+  boardUri: string;
+  linkType: string;
+  createdAt: string;
+}
+
 // --- Block types (local-only, not synced to PDS) ---
 
 export interface Block {


### PR DESCRIPTION
## Summary

- Add new `dev.skyboard.link` AT Protocol record type for directional task-to-task relationships
- Support three link types: blocks, relates to, duplicates
- Full-stack implementation across frontend (Svelte), appview (Bun/SQLite), and AT Protocol lexicons

## Changes

**Data layer:**
- New `dev.skyboard.link` lexicon definition
- Link/LinkRecord types and LINK_COLLECTION constant in types.ts
- Dexie table (version 11) with indexes on boardUri, sourceTaskUri, targetTaskUri, syncStatus
- CRUD helpers in links.ts (createLink, deleteLink)

**Sync & Auth:**
- Link sync to PDS in syncPendingToPDS, deleteBoardFromPDS, deleteLinkFromPDS, resetErrorsToPending
- OAuth scope updated with `repo:dev.skyboard.link`

**Appview:**
- SQLite schema with links table and boardUri index
- LinkRow interface + upsert/get/delete functions in client.ts
- LinkRecordSchema Zod validation
- Firehose processor handles link create/delete events
- Links included in BoardResponse from get-board API

**Frontend UI:**
- Board page: allLinks liveQuery, linksByTask/linkCountsByTask derived values, link sync error reauth banner
- TaskCard: link count badge with chain-link icon
- TaskEditModal: full Links section with add link form (type selector + task picker), directional labels (blocks/blocked by, relates to, duplicates/duplicated by), and delete button

## Test plan

- [ ] Verify type check passes (`npm run check`)
- [ ] Verify build succeeds (`npm run build`)
- [ ] Create links between tasks and verify they appear on both source and target cards
- [ ] Test all three link types (blocks, relates to, duplicates)
- [ ] Verify directional labels display correctly (blocks vs blocked by)
- [ ] Verify link deletion works for link author and board owner
- [ ] Verify links sync to PDS and appear via WebSocket updates
- [ ] Verify reauth banner appears on link sync errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)