### PR TITLE
Add Shift+N shortcut to prepend card at top of column

### DIFF
--- a/src/lib/components/KeyboardShortcutsModal.svelte
+++ b/src/lib/components/KeyboardShortcutsModal.svelte
@@ -38,6 +38,7 @@
         { keys: ["e"], description: "Inline edit task title" },
         { keys: ["t"], description: "Quick label selected task" },
         { keys: ["n"], description: "New task in current column" },
+        { keys: ["\u21E7", "N"], description: "New task at top of column" },
       ],
     },
     {

--- a/src/routes/board/[did]/[rkey]/+page.svelte
+++ b/src/routes/board/[did]/[rkey]/+page.svelte
@@ -327,13 +327,22 @@
 
   // Create a new empty card and start inline editing its title.
   // afterRow: insert after this row index. If undefined, insert at bottom.
-  function addNewCard(colIdx: number, afterRow?: number) {
+  // prepend: if true, insert at the top of the column.
+  function addNewCard(
+    colIdx: number,
+    afterRow?: number,
+    { prepend = false }: { prepend?: boolean } = {},
+  ) {
     if (!auth.did) return;
     const colTasks = sortedTasksByColumn[colIdx] ?? [];
     let before: string | null;
     let after: string | null;
     let insertRow: number;
-    if (afterRow !== undefined && colTasks.length > 0) {
+    if (prepend) {
+      before = null;
+      after = colTasks[0]?.effectivePosition ?? null;
+      insertRow = 0;
+    } else if (afterRow !== undefined && colTasks.length > 0) {
       before = colTasks[afterRow]?.effectivePosition ?? null;
       after = colTasks[afterRow + 1]?.effectivePosition ?? null;
       insertRow = afterRow + 1;
@@ -567,6 +576,13 @@
             ? pos.row
             : undefined;
         addNewCard(col, afterRow);
+        break;
+      }
+      case "N": {
+        if (!auth.did || !e.shiftKey) break;
+        e.preventDefault();
+        const prependCol = pos ? pos.col : 0;
+        addNewCard(prependCol, undefined, { prepend: true });
         break;
       }
       case "m": {


### PR DESCRIPTION
## Summary

- Adds `Shift+N` keyboard shortcut to create a new card at the **top** of the current column (prepend)
- Adds `prepend` option to `addNewCard()` using `generateKeyBetween(null, firstPosition)` to place the card before all others
- Documents the new shortcut in the keyboard shortcuts modal

## Test plan

- [ ] Press `Shift+N` on a column with cards — new card appears at top in inline edit mode
- [ ] Press `Shift+N` on an empty column — new card appears and enters inline edit mode
- [ ] Verify existing `n` shortcut still inserts after selected card
- [ ] Verify shortcut is a no-op when not authenticated
- [ ] Check keyboard shortcuts modal (`?`) shows the new `⇧ N` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)