### PR TITLE
Fix delayed sync on mobile Safari

### DIFF
--- a/src/lib/approvals.ts
+++ b/src/lib/approvals.ts
@@ -2,6 +2,7 @@ import { db } from "./db.js";
 import { generateTID, APPROVAL_COLLECTION } from "./tid.js";
 import { getAuth } from "./auth.svelte.js";
 import type { Approval, ApprovalRecord } from "./types.js";
+import { notifyPendingWrite } from "./sync.js";
 
 export async function createApproval(
   ownerDid: string,
@@ -16,6 +17,7 @@ export async function createApproval(
     createdAt: new Date().toISOString(),
     syncStatus: "pending",
   });
+  notifyPendingWrite();
 }
 
 export async function deleteApproval(approval: Approval): Promise<void> {

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -2,6 +2,7 @@ import { db } from "./db.js";
 import { generateTID, COMMENT_COLLECTION } from "./tid.js";
 import { getAuth } from "./auth.svelte.js";
 import type { Comment, CommentRecord } from "./types.js";
+import { notifyPendingWrite } from "./sync.js";
 
 export async function createComment(
   authorDid: string,
@@ -18,6 +19,7 @@ export async function createComment(
     createdAt: new Date().toISOString(),
     syncStatus: "pending",
   });
+  notifyPendingWrite();
 }
 
 export async function deleteComment(comment: Comment): Promise<void> {

--- a/src/lib/components/BoardSettingsModal.svelte
+++ b/src/lib/components/BoardSettingsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { db } from "$lib/db.js";
   import { generateTID } from "$lib/tid.js";
+  import { notifyPendingWrite } from "$lib/sync.js";
   import type { Board, Column, Label } from "$lib/types.js";
 
   let {
@@ -83,6 +84,7 @@
       labels: labels.length > 0 ? labels.map((l) => ({ ...l })) : undefined,
       syncStatus: "pending",
     });
+    notifyPendingWrite();
 
     onclose();
   }

--- a/src/lib/components/TaskEditModal.svelte
+++ b/src/lib/components/TaskEditModal.svelte
@@ -5,7 +5,7 @@
   import { createOp } from "$lib/ops.js";
   import { createComment, deleteComment } from "$lib/comments.js";
   import { getAuth } from "$lib/auth.svelte.js";
-  import { deleteTaskFromPDS } from "$lib/sync.js";
+  import { deleteTaskFromPDS, notifyPendingWrite } from "$lib/sync.js";
   import { getActionStatus, isContentVisible } from "$lib/permissions.js";
   import type { PermissionStatus } from "$lib/permissions.js";
   import { COMMENT_COLLECTION, buildAtUri, generateTID } from "$lib/tid.js";
@@ -379,6 +379,7 @@
       labels: [...existingLabels, newLabel],
       syncStatus: "pending",
     });
+    notifyPendingWrite();
 
     // Auto-select the newly created label
     editLabelIds = [...editLabelIds, newLabel.id];

--- a/src/lib/ops.ts
+++ b/src/lib/ops.ts
@@ -1,6 +1,7 @@
 import { db } from "./db.js";
 import { generateTID, buildAtUri, TASK_COLLECTION } from "./tid.js";
 import type { Op, OpFields, OpRecord, Task } from "./types.js";
+import { notifyPendingWrite } from "./sync.js";
 
 export async function createOp(
   authorDid: string,
@@ -23,6 +24,7 @@ export async function createOp(
     createdAt: new Date().toISOString(),
     syncStatus: "pending",
   });
+  notifyPendingWrite();
 }
 
 export function opToRecord(op: Op): OpRecord {

--- a/src/lib/reactions.ts
+++ b/src/lib/reactions.ts
@@ -2,6 +2,7 @@ import { db } from "./db.js";
 import { generateTID, REACTION_COLLECTION } from "./tid.js";
 import { getAuth } from "./auth.svelte.js";
 import type { Reaction, ReactionRecord } from "./types.js";
+import { notifyPendingWrite } from "./sync.js";
 
 export async function toggleReaction(
   did: string,
@@ -26,6 +27,7 @@ export async function toggleReaction(
       createdAt: new Date().toISOString(),
       syncStatus: "pending",
     });
+    notifyPendingWrite();
   }
 }
 

--- a/src/lib/trust.ts
+++ b/src/lib/trust.ts
@@ -1,6 +1,6 @@
 import { db } from "./db.js";
 import { generateTID } from "./tid.js";
-import { deleteTrustFromPDS } from "./sync.js";
+import { deleteTrustFromPDS, notifyPendingWrite } from "./sync.js";
 import { getAuth } from "./auth.svelte.js";
 import type { Trust, TrustRecord } from "./types.js";
 
@@ -23,6 +23,7 @@ export async function grantTrust(
     createdAt: new Date().toISOString(),
     syncStatus: "pending",
   });
+  notifyPendingWrite();
 }
 
 export async function revokeTrust(


### PR DESCRIPTION
## Summary

- Adds `visibilitychange` and `pagehide` event listeners to flush pending records before the browser throttles/suspends timers on mobile Safari
- Adds a debounced `notifyPendingWrite()` function that triggers sync within 300ms of any Dexie write, instead of waiting up to 5 seconds for the polling interval
- Adds a concurrency guard to prevent overlapping `syncPendingToPDS` calls
- Calls `notifyPendingWrite()` from all write sites: ops, comments, trusts, approvals, reactions, task creation, board settings

## Test plan

- [ ] Verify sync still works on desktop browsers (no regression)
- [ ] On mobile Safari: make a change, switch apps immediately, verify the change syncs
- [ ] On mobile Safari: lock screen after a change, verify it synced before suspension
- [ ] Verify rapid writes are batched (300ms debounce, no duplicate sync runs)
- [ ] Run `npm run check` — passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)