### PR TITLE
Hide header items on small screens

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -567,5 +567,13 @@
       padding: 0.3125rem 0.5rem;
       font-size: 0.75rem;
     }
+
+    .github-link {
+      display: none;
+    }
+
+    .help-btn {
+      display: none;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- Hide GitHub link and help button (?) on screens ≤600px wide
- These are low-priority items on mobile: GitHub link is rarely needed, help button shows keyboard shortcuts irrelevant on touch devices
- Reduces header-right from 7 items to 5 on small screens

## Test plan
- [ ] Verify GitHub link is hidden at ≤600px viewport width
- [ ] Verify help button (?) is hidden at ≤600px viewport width
- [ ] Verify all other header items (SyncStatus, bell, theme, avatar, Sign Out) remain visible
- [ ] Verify no changes to header at >600px width
- [ ] Verify logged-out header also hides GitHub link on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)