### PR TITLE
Add ability to edit comments on cards

### DIFF
--- a/appview/src/api/get-board.ts
+++ b/appview/src/api/get-board.ts
@@ -201,6 +201,7 @@ export interface BoardResponse {
     targetTaskUri: string;
     text: string;
     createdAt: string;
+    updatedAt: string | null;
   }>;
   approvals: Array<{
     uri: string;
@@ -287,6 +288,7 @@ export function getBoardData(did: string, rkey: string): BoardResponse | null {
       targetTaskUri: c.targetTaskUri,
       text: c.text,
       createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
     })),
     approvals: approvalRows.map((a) => ({
       uri: a.uri,

--- a/appview/src/db/schema.sql
+++ b/appview/src/db/schema.sql
@@ -59,7 +59,8 @@ CREATE TABLE IF NOT EXISTS comments (
   targetTaskUri TEXT NOT NULL,
   boardUri TEXT NOT NULL,
   text TEXT NOT NULL,
-  createdAt TEXT NOT NULL
+  createdAt TEXT NOT NULL,
+  updatedAt TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_comments_did_rkey ON comments(did, rkey);
 CREATE INDEX IF NOT EXISTS idx_comments_boardUri ON comments(boardUri);

--- a/appview/src/firehose/processor.ts
+++ b/appview/src/firehose/processor.ts
@@ -228,6 +228,7 @@ function processComment(
     boardUri,
     text: validated.text,
     createdAt: validated.createdAt,
+    updatedAt: validated.updatedAt,
   });
   upsertParticipant(did, boardUri);
   return boardUri;

--- a/appview/src/shared/schemas.ts
+++ b/appview/src/shared/schemas.ts
@@ -68,6 +68,7 @@ export const CommentRecordSchema = z.object({
   boardUri: z.string().max(MAX_STRING),
   text: z.string().max(MAX_STRING),
   createdAt: z.string().max(MAX_STRING),
+  updatedAt: z.string().max(MAX_STRING).optional(),
 });
 
 export const ApprovalRecordSchema = z.object({

--- a/src/lib/appview.ts
+++ b/src/lib/appview.ts
@@ -227,6 +227,7 @@ export async function loadBoardFromAppview(
             boardUri,
             text: c.text,
             createdAt: c.createdAt,
+            updatedAt: c.updatedAt ?? undefined,
             syncStatus: "synced",
           };
 
@@ -241,6 +242,7 @@ export async function loadBoardFromAppview(
                 "targetTaskUri",
                 "text",
                 "createdAt",
+                "updatedAt",
               ])
             ) {
               await db.comments.update(existing.id, commentData);

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -43,12 +43,29 @@ export async function deleteComment(comment: Comment): Promise<void> {
   await db.comments.delete(comment.id);
 }
 
+export async function updateComment(
+  comment: Comment,
+  newText: string,
+): Promise<void> {
+  if (!comment.id) return;
+  await db.comments.update(comment.id, {
+    text: newText,
+    updatedAt: new Date().toISOString(),
+    syncStatus: "pending",
+  });
+  notifyPendingWrite();
+}
+
 export function commentToRecord(comment: Comment): CommentRecord {
-  return {
+  const record: CommentRecord = {
     $type: "dev.skyboard.comment",
     targetTaskUri: comment.targetTaskUri,
     boardUri: comment.boardUri,
     text: comment.text,
     createdAt: comment.createdAt,
   };
+  if (comment.updatedAt) {
+    record.updatedAt = comment.updatedAt;
+  }
+  return record;
 }

--- a/src/lib/lexicons/comment.json
+++ b/src/lib/lexicons/comment.json
@@ -29,6 +29,11 @@
             "type": "string",
             "format": "datetime",
             "description": "When the comment was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the comment was last edited"
           }
         }
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,6 +124,7 @@ export interface Comment {
   boardUri: string;
   text: string;
   createdAt: string;
+  updatedAt?: string;
   syncStatus: SyncStatus;
 }
 
@@ -133,6 +134,7 @@ export interface CommentRecord {
   boardUri: string;
   text: string;
   createdAt: string;
+  updatedAt?: string;
 }
 
 // --- Reaction types ---


### PR DESCRIPTION
## Summary

- Adds `updatedAt` optional field to the comment lexicon, data model (Comment/CommentRecord), and appview schema
- Adds `updateComment()` function in `src/lib/comments.ts` that updates text + updatedAt and triggers sync
- Updates `commentToRecord()` to include `updatedAt` when present
- Adds inline edit UI in TaskEditModal: edit/cancel buttons appear on hover for own comments
- Shows "(edited)" indicator with tooltip showing edit time when a comment has been edited
- Updates appview: schema migration for existing databases, upsertComment includes updatedAt, firehose processor passes updatedAt through
- Frontend appview.ts loads updatedAt from the appview response

## Test plan

- [ ] Create a comment on a card, verify it appears normally
- [ ] Hover over own comment, verify edit (pencil) and delete buttons appear
- [ ] Click edit, verify textarea shows current comment text
- [ ] Edit text and click Save, verify comment updates and shows "(edited)"
- [ ] Hover over "(edited)" to verify tooltip shows edit timestamp
- [ ] Click Cancel during edit, verify original text is preserved
- [ ] Verify other users' comments do not show edit button
- [ ] Verify comment editing syncs to PDS (check sync status dot)
- [ ] Verify `npm run check` passes with 0 errors
- [ ] Verify `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)