### PR TITLE
Add active column highlighting for keyboard navigation

### DIFF
--- a/src/lib/components/Column.svelte
+++ b/src/lib/components/Column.svelte
@@ -28,6 +28,7 @@
     onedit,
     onreact,
     readonly = false,
+    isActiveColumn = false,
     selectedTaskIndex = null,
     editingTaskIndex = null,
     onsavetitle,
@@ -53,6 +54,7 @@
     onedit: (task: MaterializedTask) => void;
     onreact?: (taskUri: string, emoji: string) => void;
     readonly?: boolean;
+    isActiveColumn?: boolean;
     selectedTaskIndex?: number | null;
     editingTaskIndex?: number | null;
     onsavetitle?: (task: MaterializedTask, title: string) => void;
@@ -257,6 +259,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="column"
+  class:column-active={isActiveColumn}
   class:drag-over={dropIndex !== null}
   data-column-id={column.id}
   bind:this={columnEl}
@@ -337,6 +340,20 @@
 
   .column.drag-over {
     background: var(--color-drag-over);
+  }
+
+  .column.column-active .column-header h3 {
+    color: var(--color-primary);
+  }
+
+  .column.column-active .task-list:empty::after {
+    content: "";
+    display: block;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--color-primary);
+    opacity: 0.3;
+    margin: 0.5rem 0;
   }
 
   .column-header {

--- a/src/routes/board/[did]/[rkey]/+page.svelte
+++ b/src/routes/board/[did]/[rkey]/+page.svelte
@@ -1283,6 +1283,7 @@
           onedit={openTaskEditor}
           onreact={handleReact}
           readonly={!auth.isLoggedIn}
+          isActiveColumn={getSelectedPos()?.col === colIdx}
           selectedTaskIndex={getSelectedPos()?.col === colIdx
             ? (getSelectedPos()?.row ?? null)
             : null}


### PR DESCRIPTION
## Summary
- Highlights the active column's header text with the primary color when navigating with h/l or arrow keys
- Shows a subtle indicator bar in empty columns so users can tell which column they're in
- No visual changes to inactive columns; no regression to drag-over or card selection styling

## Test plan
- [ ] Navigate between columns with h/l or arrow keys — active column header should highlight
- [ ] Navigate into an empty column — a small colored bar should appear in the task list area
- [ ] Verify mouse hover on cards still sets the active column correctly
- [ ] Verify drag-over styling is unaffected
- [ ] Verify both light and dark modes look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)